### PR TITLE
fix gradle application plugin settings to make it buildable with gradle 3.1

### DIFF
--- a/examples/mapreduce-bitcoinblock/build.gradle
+++ b/examples/mapreduce-bitcoinblock/build.gradle
@@ -18,6 +18,8 @@ jar {
    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
 }
 
+mainClassName = "org.zuinnote.spark2.bitcoin.example.Spark2BitcoinBlockCounter"
+
 repositories {
     mavenCentral()
 }

--- a/examples/mapreduce-bitcointransaction/build.gradle
+++ b/examples/mapreduce-bitcointransaction/build.gradle
@@ -16,6 +16,8 @@ jar {
    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
 }
 
+mainClassName = "org.zuinnote.spark2.bitcoin.example.driver.BitcoinTransactionCounterDriver"
+
 repositories {
     mavenCentral()
 }

--- a/examples/spark-bitcoinblock/build.gradle
+++ b/examples/spark-bitcoinblock/build.gradle
@@ -9,12 +9,14 @@ jar {
     manifest {
         attributes 'Implementation-Title': 'Example - Spark job (BitcoinBlock) for analysing Bitcoin data using hadoopcryptoledger', 'Implementation-Version': version
     }
- 
+
     baseName = 'example-hcl-spark-bitcoinblock'
     version = '0.1.0'
    // note this builds one fat jar and it is not recommended for production use - just for illustration purpose
    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
 }
+
+mainClassName = "org.zuinnote.spark.bitcoin.example.SparkBitcoinBlockCounter"
 
 repositories {
     mavenCentral()

--- a/examples/spark2-bitcoinblock-dataset/build.gradle
+++ b/examples/spark2-bitcoinblock-dataset/build.gradle
@@ -16,6 +16,8 @@ jar {
    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
 }
 
+mainClassName = "org.zuinnote.spark.bitcoin.example.Spark2DataSetBitcoinBlockCounter"
+
 repositories {
     mavenCentral()
 }

--- a/examples/spark2-bitcoinblock/build.gradle
+++ b/examples/spark2-bitcoinblock/build.gradle
@@ -16,6 +16,8 @@ jar {
    from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
 }
 
+mainClassName = "org.zuinnote.spark.bitcoin.example.SparkBitcoinBlockCounter"
+
 repositories {
     mavenCentral()
 }

--- a/hiveserde/build.gradle
+++ b/hiveserde/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'application'
 apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'jacoco'

--- a/hiveudf/build.gradle
+++ b/hiveudf/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'application'
 apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'jacoco'

--- a/inputformat/build.gradle
+++ b/inputformat/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-apply plugin: 'application'
 apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'jacoco'


### PR DESCRIPTION
With gradle 3.1 the project can't be built:

```
:hiveserde:clean
:hiveudf:clean UP-TO-DATE
:inputformat:clean UP-TO-DATE
:examples:mapreduce-bitcoinblock:clean UP-TO-DATE
:examples:mapreduce-bitcointransaction:clean UP-TO-DATE
:examples:spark-bitcoinblock:clean UP-TO-DATE
:examples:spark2-bitcoinblock:clean UP-TO-DATE
:examples:spark2-bitcoinblock-dataset:clean UP-TO-DATE
:hiveserde:compileJavawarning: [options] bootstrap class path not set in conjunction with -source 1.7
1 warning

:hiveserde:processResources UP-TO-DATE
:hiveserde:classes
:hiveserde:jar
:hiveserde:startScripts FAILED

FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':hiveserde:startScripts'.
> No value has been specified for property 'mainClassName'.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
```

I removed the unnecessary application plugins and added the mainClass for the examples projects.