### PR TITLE
Introduce reader on transaction element level

### DIFF
--- a/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/BitcoinTransactionElement.java
+++ b/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/BitcoinTransactionElement.java
@@ -1,0 +1,68 @@
+package org.zuinnote.hadoop.bitcoin.format;
+
+public class BitcoinTransactionElement {
+    private byte[] blockHash;
+    private int transactionIdxInBlock;
+    private byte[] transactionHash;
+    private int type;
+    private int indexInTransaction;
+    private long amount;
+    private byte[] script;
+
+    public byte[] getBlockHash() {
+        return blockHash;
+    }
+
+    public void setBlockHash(byte[] blockHash) {
+        this.blockHash = blockHash;
+    }
+
+    public int getTransactionIdxInBlock() {
+        return transactionIdxInBlock;
+    }
+
+    public void setTransactionIdxInBlock(int transactionIdxInBlock) {
+        this.transactionIdxInBlock = transactionIdxInBlock;
+    }
+
+    public byte[] getTransactionHash() {
+        return transactionHash;
+    }
+
+    public void setTransactionHash(byte[] transactionHash) {
+        this.transactionHash = transactionHash;
+    }
+
+    public int getType() {
+        return type;
+    }
+
+    public void setType(int type) {
+        this.type = type;
+    }
+
+    public int getIndexInTransaction() {
+        return indexInTransaction;
+    }
+
+    public void setIndexInTransaction(int indexInTransaction) {
+        this.indexInTransaction = indexInTransaction;
+    }
+
+    public long getAmount() {
+        return amount;
+    }
+
+    public void setAmount(long amount) {
+        this.amount = amount;
+    }
+
+
+    public byte[] getScript() {
+        return script;
+    }
+
+    public void setScript(byte[] script) {
+        this.script = script;
+    }
+}

--- a/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/BitcoinTransactionElementFileInputFormat.java
+++ b/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/BitcoinTransactionElementFileInputFormat.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package org.zuinnote.hadoop.bitcoin.format;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.io.compress.SplittableCompressionCodec;
+import org.apache.hadoop.mapred.*;
+import org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException;
+import org.zuinnote.hadoop.bitcoin.format.exception.HadoopCryptoLedgerConfigurationException;
+
+import java.io.IOException;
+
+public class BitcoinTransactionElementFileInputFormat extends FileInputFormat<BytesWritable, BitcoinTransactionElement> implements JobConfigurable {
+
+    private static final Log LOG = LogFactory.getLog(BitcoinTransactionElementFileInputFormat.class.getName());
+    private static final String CONF_ISSPLITABLE = "hadoopcryptoledeger.bitcoinblockinputformat.issplitable";
+    private static final boolean DEFAULT_ISSPLITABLE = false;
+    private boolean isSplitable = DEFAULT_ISSPLITABLE;
+    private CompressionCodecFactory compressionCodecs = null;
+
+
+    public RecordReader<BytesWritable, BitcoinTransactionElement> getRecordReader(InputSplit split, JobConf job, Reporter reporter) throws IOException {
+        /** Create reader **/
+        try {
+            return new BitcoinTransactionElementRecordReader((FileSplit) split, job, reporter);
+        } catch (HadoopCryptoLedgerConfigurationException e) {
+            // log
+            LOG.error(e);
+        } catch (BitcoinBlockReadException e) {
+            // log
+            LOG.error(e);
+        }
+        return null;
+    }
+
+
+    public void configure(JobConf conf) {
+        this.compressionCodecs = new CompressionCodecFactory(conf);
+        this.isSplitable = conf.getBoolean(this.CONF_ISSPLITABLE, this.DEFAULT_ISSPLITABLE);
+    }
+
+    /**
+     *
+     * This method is experimental and derived from TextInputFormat. It is not necessary and not recommended to compress the blockchain files. Instead it is recommended to extract relevant data from the blockchain files once and store them in a format suitable for analytics (including compression), such as ORC or Parquet.
+     *
+     */
+
+    protected boolean isSplitable(FileSystem fs, Path file) {
+        if (this.isSplitable == false) return false;
+        final CompressionCodec codec = compressionCodecs.getCodec(file);
+        if (null == codec) {
+            return true;
+        }
+        return codec instanceof SplittableCompressionCodec;
+
+    }
+
+
+}

--- a/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/BitcoinTransactionElementRecordReader.java
+++ b/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/BitcoinTransactionElementRecordReader.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package org.zuinnote.hadoop.bitcoin.format;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.Reporter;
+import org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException;
+import org.zuinnote.hadoop.bitcoin.format.exception.HadoopCryptoLedgerConfigurationException;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+
+public class BitcoinTransactionElementRecordReader extends AbstractBitcoinRecordReader<BytesWritable, BitcoinTransactionElement> {
+    private static final Log LOG = LogFactory.getLog(BitcoinBlockRecordReader.class.getName());
+
+    private int currentTransactionCounterInBlock = 0;
+
+    private int currentInputCounter = 0;
+
+    private int currentOutputCounter = 0;
+
+    private BitcoinBlock currentBitcoinBlock;
+
+    private BitcoinTransaction currentTransaction;
+
+
+    public BitcoinTransactionElementRecordReader(FileSplit split, JobConf job, Reporter reporter) throws IOException, HadoopCryptoLedgerConfigurationException, BitcoinBlockReadException {
+        super(split, job, reporter);
+    }
+
+    /**
+     * Create an empty key
+     *
+     * @return key
+     */
+    public BytesWritable createKey() {
+        return new BytesWritable();
+    }
+
+    /**
+     * Create an empty value
+     *
+     * @return value
+     */
+    public BitcoinTransactionElement createValue() {
+        return new BitcoinTransactionElement();
+    }
+
+
+    /**
+     * Read a next block.
+     *
+     * @param key   is a 68 byte array (hashMerkleRoot, prevHashBlock, transActionCounter)
+     * @param value is a deserialized Java object of class BitcoinBlock
+     * @return true if next block is available, false if not
+     */
+    public boolean next(BytesWritable key, BitcoinTransactionElement value) throws IOException {
+        // read all the blocks, if necessary a block overlapping a split´
+        try {
+            while (getFilePosition() <= getEnd()) { // did we already went beyond the split (remote) or do we have no further data left?
+                if ((currentBitcoinBlock == null) || (currentBitcoinBlock.getTransactions().size() == currentTransactionCounterInBlock)) {
+                    currentBitcoinBlock = getBbr().readBlock();
+                    if (currentBitcoinBlock == null) return false;
+                    currentTransactionCounterInBlock = 0;
+                    currentInputCounter = 0;
+                    currentOutputCounter = 0;
+                }
+                currentTransaction = currentBitcoinBlock.getTransactions().get(currentTransactionCounterInBlock);
+
+                byte[] blockHash = BitcoinUtil.getBlockHash(currentBitcoinBlock);
+                byte[] transactionHash = BitcoinUtil.getTransactionHash(currentTransaction);
+                value.setBlockHash(blockHash);
+                value.setTransactionIdxInBlock(currentTransactionCounterInBlock);
+                if (currentTransaction.getListOfInputs().size() > currentInputCounter) {
+                    value.setType(0);
+                    BitcoinTransactionInput input = currentTransaction.getListOfInputs().get(currentInputCounter);
+                    currentInputCounter++;
+                    value.setAmount(0);
+                    value.setTransactionHash(BitcoinUtil.reverseByteArray(input.getPrevTransactionHash()));
+                    value.setScript(input.getTxInScript());
+                    byte[] keyBytes = createUniqKey(transactionHash, 0, currentInputCounter);
+                    key.set(keyBytes, 0, keyBytes.length);
+                    return true;
+                } else if (currentTransaction.getListOfOutputs().size() > currentOutputCounter) {
+                    value.setType(1);
+                    BitcoinTransactionOutput output = currentTransaction.getListOfOutputs().get(currentOutputCounter);
+                    value.setAmount(output.getValue());
+                    value.setIndexInTransaction(currentOutputCounter);
+                    value.setTransactionHash(transactionHash);
+                    value.setScript(output.getTxOutScript());
+                    byte[] keyBytes = createUniqKey(transactionHash, 1, currentOutputCounter);
+                    key.set(keyBytes, 0, keyBytes.length);
+
+                    //return an output
+                    currentOutputCounter++;
+                    return true;
+                } else {
+                    currentInputCounter = 0;
+                    currentOutputCounter = 0;
+                    currentTransactionCounterInBlock++;
+                    return next(key, value);
+                }
+            }
+            return false;
+        } catch (Exception e) {
+            // log
+            LOG.error(e);
+            return false;
+        }
+    }
+
+    private byte[] createUniqKey(byte[] transactionHash, int type, int counter) {
+        byte[] result = new byte[transactionHash.length + 1 + 4];
+        System.arraycopy(transactionHash, 0, result, 0, transactionHash.length);
+        System.arraycopy(new byte[]{(byte) type}, 0, result, transactionHash.length, 1);
+        System.arraycopy(ByteBuffer.allocate(4).putInt(counter).array(), 0, result, transactionHash.length + 1, 4);
+        return result;
+    }
+
+
+}

--- a/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/BitcoinUtil.java
+++ b/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/BitcoinUtil.java
@@ -35,6 +35,7 @@ import org.apache.commons.logging.Log;
 
 
 public class BitcoinUtil {
+
 private static final Log LOG = LogFactory.getLog(BitcoinUtil.class.getName());
 
 /**
@@ -301,6 +302,22 @@ public static byte[] getTransactionHash(BitcoinTransaction transaction) throws N
 	return finalHash;
 }
 
+	public static byte[] getBlockHash(BitcoinBlock block) throws NoSuchAlgorithmException, IOException {
+		ByteArrayOutputStream blockBAOS = new ByteArrayOutputStream();
+		String merkleTree = convertByteArrayToHexString(block.getHashMerkleRoot()).toLowerCase();
+		blockBAOS.write(reverseByteArray(convertIntToByteArray(block.getVersion())));
+		blockBAOS.write(block.getHashPrevBlock());
+		blockBAOS.write(block.getHashMerkleRoot());
+		blockBAOS.write(reverseByteArray(convertIntToByteArray(block.getTime())));
+		blockBAOS.write(block.getBits());
+		blockBAOS.write(reverseByteArray(convertIntToByteArray(block.getNonce())));
+		byte[] blockByteArray = blockBAOS.toByteArray();
+		MessageDigest digest = MessageDigest.getInstance("SHA-256");
+		byte[] firstRoundHash = digest.digest(blockByteArray);
+		byte[] secondRoundHash = digest.digest(firstRoundHash);
+		byte[] finalHash = secondRoundHash;
+		return reverseByteArray(finalHash);
+    }
 
 
 }

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/BitcoinFormatReaderTest.java
@@ -36,9 +36,9 @@ import org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException;
 
 
 public class BitcoinFormatReaderTest {
-private static final int DEFAULT_BUFFERSIZE=64*1024;
-private static final int DEFAULT_MAXSIZE_BITCOINBLOCK=1 * 1024 * 1024;
-private static final byte[][] DEFAULT_MAGIC = {{(byte)0xF9,(byte)0xBE,(byte)0xB4,(byte)0xD9}};
+static final int DEFAULT_BUFFERSIZE=64*1024;
+static final int DEFAULT_MAXSIZE_BITCOINBLOCK=1 * 1024 * 1024;
+static final byte[][] DEFAULT_MAGIC = {{(byte)0xF9,(byte)0xBE,(byte)0xB4,(byte)0xD9}};
 private static final byte[][] TESTNET3_MAGIC = {{(byte)0x0B,(byte)0x11,(byte)0x09,(byte)0x07}};
 private static final byte[][] MULTINET_MAGIC = {{(byte)0xF9,(byte)0xBE,(byte)0xB4,(byte)0xD9},{(byte)0x0B,(byte)0x11,(byte)0x09,(byte)0x07}};
 

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/BitcoinUtilTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/BitcoinUtilTest.java
@@ -20,8 +20,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -33,6 +37,7 @@ import java.util.Date;
 import java.security.NoSuchAlgorithmException;
 
 import org.zuinnote.hadoop.bitcoin.format.BitcoinUtil;
+import org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException;
 
 public class BitcoinUtilTest {
 
@@ -199,6 +204,29 @@ public class BitcoinUtilTest {
     assertFalse("Magic 1 {0xF9,0xBE,0xB4,0xD9} is not equivalent to Magic 2 {0xFA,0xBF,0xB5,0xDA}", isSame);
   }
 
+
+  @Test
+  public void getBlockHash() throws NoSuchAlgorithmException, IOException {
+    ClassLoader classLoader = getClass().getClassLoader();
+    String fullFileNameString=classLoader.getResource("testdata/genesis.blk").getFile();
+    File file = new File(fullFileNameString);
+    BitcoinBlockReader bbr = null;
+    boolean direct=false;
+    try {
+      FileInputStream fin = new FileInputStream(file);
+      bbr = new BitcoinBlockReader(fin,BitcoinFormatReaderTest.DEFAULT_MAXSIZE_BITCOINBLOCK,BitcoinFormatReaderTest.DEFAULT_BUFFERSIZE,BitcoinFormatReaderTest.DEFAULT_MAGIC,false);
+      BitcoinBlock genesisBlock = bbr.readBlock();
+
+
+      Assert.assertEquals("000000000019D6689C085AE165831E934FF763AE46A2A6C172B3F1B60A8CE26F",BitcoinUtil.convertByteArrayToHexString(BitcoinUtil.getBlockHash(genesisBlock)));
+
+    } catch (BitcoinBlockReadException e) {
+      Assert.fail("Block reading has been failed");
+    } finally {
+      if (bbr!=null)
+        bbr.close();
+    }
+  }
   @Test
   public void getTransactionHash() throws NoSuchAlgorithmException, IOException {
 	 // reconstruct the transaction from the genesis block


### PR DESCRIPTION
For calculating the unspent transaction outputs we need a reader which reads transaction input and output elements as records and not the transaction itself. The patch introduce a new reader based on the existing ones (and a blockHash calculator)