### PR TITLE
Adding looped read on listHeader for ethereum reader

### DIFF
--- a/inputformat/src/main/java/org/zuinnote/hadoop/ethereum/format/common/EthereumBlockReader.java
+++ b/inputformat/src/main/java/org/zuinnote/hadoop/ethereum/format/common/EthereumBlockReader.java
@@ -176,9 +176,6 @@ public class EthereumBlockReader {
 	}
 
 
-
-
-
 	/*
 	 * Reads a raw Ethereum block into a ByteBuffer. This method is recommended if you are only interested in a small part of the block and do not need the deserialization of the full block, ie in case you generally skip a lot of blocks
 	 * 
@@ -190,13 +187,20 @@ public class EthereumBlockReader {
 		// get size of list
 		this.in.mark(10);
 		byte[] listHeader = new byte[10];
+		int totalRead = 0;
 		int bRead=this.in.read(listHeader);
-		if (bRead==-1) {
+		if (bRead == -1) {
 			// no further block to read
 			return result;
-		} else
-		if (bRead!=10) {
-			throw new EthereumBlockReadException("Error: Not enough block data available: "+String.valueOf(bRead));
+		} else {
+			totalRead += bRead;
+			while (totalRead < 10) {
+				bRead=this.in.read(listHeader, totalRead, 10 - totalRead);
+				if (bRead == -1) {
+					throw new EthereumBlockReadException("Error: Not enough block data available: " + String.valueOf(bRead));
+				}
+				totalRead += bRead;
+			}
 		}
 		ByteBuffer sizeByteBuffer=ByteBuffer.wrap(listHeader);
 		long blockSize = EthereumUtil.getRLPListSize(sizeByteBuffer); // gets block size including indicator


### PR DESCRIPTION
The EthereumBlockReader is read the first 10 bytes in a block being the listHeader variable. (line 193)
Since read operations may return less than the maximal amount allowed even if there is data available,
when reading from a remote location (in my tests, running on EMR and S3) the call fails, thinking there is not enough data for a list header.
Reading in a loop until reaching 10 bytes or recieving a -1 return code solves this issue
