### PR TITLE
Test for correct time field and refactoring to remove duplicated code in BitcoinFormatReaderTest 

### DIFF
--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
@@ -49,7 +49,7 @@ public class BitcoinFormatReaderTest {
                 "reqseekversion1.blk", "testnet3genesis.blk", "testnet3version4.blk", "testnet3version4.blk",
                 "multinet.blk", "scriptwitness.blk", "scriptwitness2.blk"};
         for(String fileName: testFiles) {
-            testAvailable(fileName);
+            assertTestFileAvailable(fileName);
         }
     }
 
@@ -217,22 +217,6 @@ public class BitcoinFormatReaderTest {
         }
     }
 
-    public void checkDateField(Calendar expected, Calendar actual, int field) {
-        assertEquals(expected.get(field), actual.get(field));
-    }
-
-    public void checkDate(Date expected, Date actual) {
-        Calendar x = new GregorianCalendar();
-        x.setTime(expected);
-        Calendar y = new GregorianCalendar();
-        y.setTime(actual);
-        Integer[] fields = new Integer[]
-            {Calendar.YEAR, Calendar.MONTH, Calendar.DAY_OF_MONTH, Calendar.HOUR_OF_DAY, Calendar.MINUTE};
-        for(int field : fields) {
-            checkDateField(x, y, field);
-        }
-    }
-
     @Test
     public void parseGenesisBlockTestTime() throws IOException, BitcoinBlockReadException, ParseException {
         BitcoinBlockReader bbr = null;
@@ -242,7 +226,7 @@ public class BitcoinFormatReaderTest {
             SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd h:m:s");
             Date genesisDate = format.parse ( "2009-01-03 18:15:05" );
             Date blockDate = new java.util.Date(genesisBlock.getTime()*1000L);
-            checkDate(genesisDate, blockDate);
+            assertDateFieldsEqual(genesisDate, blockDate);
         } finally {
             if (bbr != null) {
                 bbr.close();
@@ -807,13 +791,6 @@ public class BitcoinFormatReaderTest {
         return Objects.requireNonNull(getClass().getClassLoader().getResource("testdata/" + fileName)).getFile();
     }
 
-    public void testAvailable(String fileName) {
-        String fullFilename = getFullFilename(fileName);
-        File file = new File(fullFilename);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
     public BitcoinBlockReader blockReader(String fileName, boolean direct) throws IOException {
         return blockReader(fileName, direct, DEFAULT_MAGIC);
     }
@@ -826,6 +803,29 @@ public class BitcoinFormatReaderTest {
 
     public BitcoinBlockReader genesisBlockReader(boolean direct) throws IOException {
         return blockReader("genesis.blk", direct);
+    }
+
+    public void assertTestFileAvailable(String fileName) {
+        String fullFilename = getFullFilename(fileName);
+        File file = new File(fullFilename);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    public void assertDateFieldEqual(Calendar expected, Calendar actual, int field) {
+        assertEquals(expected.get(field), actual.get(field));
+    }
+
+    public void assertDateFieldsEqual(Date expected, Date actual) {
+        Calendar x = new GregorianCalendar();
+        x.setTime(expected);
+        Calendar y = new GregorianCalendar();
+        y.setTime(actual);
+        Integer[] fields = new Integer[]
+                {Calendar.YEAR, Calendar.MONTH, Calendar.DAY_OF_MONTH, Calendar.HOUR_OF_DAY, Calendar.MINUTE};
+        for(int field : fields) {
+            assertDateFieldEqual(x, y, field);
+        }
     }
 
 }

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
@@ -388,7 +388,7 @@ public class BitcoinFormatReaderTest {
 
 
     @Test
-    public void parseGenesisBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+    public void parseGenesisBlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         ClassLoader classLoader = getClass().getClassLoader();
         String fileName = "genesis.blk";
         String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
@@ -17,11 +17,8 @@
 package org.zuinnote.hadoop.bitcoin.format.common;
 
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,1168 +27,1184 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 
-import org.junit.jupiter.api.Test;
-import org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class BitcoinFormatReaderTest {
-static final int DEFAULT_BUFFERSIZE=64*1024;
-static final int DEFAULT_MAXSIZE_BITCOINBLOCK=8 * 1024 * 1024;
-static final byte[][] DEFAULT_MAGIC = {{(byte)0xF9,(byte)0xBE,(byte)0xB4,(byte)0xD9}};
-private static final byte[][] TESTNET3_MAGIC = {{(byte)0x0B,(byte)0x11,(byte)0x09,(byte)0x07}};
-private static final byte[][] MULTINET_MAGIC = {{(byte)0xF9,(byte)0xBE,(byte)0xB4,(byte)0xD9},{(byte)0x0B,(byte)0x11,(byte)0x09,(byte)0x07}};
+    static final int DEFAULT_BUFFERSIZE = 64 * 1024;
+    static final int DEFAULT_MAXSIZE_BITCOINBLOCK = 8 * 1024 * 1024;
+    static final byte[][] DEFAULT_MAGIC = {{(byte) 0xF9, (byte) 0xBE, (byte) 0xB4, (byte) 0xD9}};
+    private static final byte[][] TESTNET3_MAGIC = {{(byte) 0x0B, (byte) 0x11, (byte) 0x09, (byte) 0x07}};
+    private static final byte[][] MULTINET_MAGIC = {{(byte) 0xF9, (byte) 0xBE, (byte) 0xB4, (byte) 0xD9}, {(byte) 0x0B, (byte) 0x11, (byte) 0x09, (byte) 0x07}};
 
- @Test
-  public void checkTestDataGenesisBlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
-
- @Test
-  public void checkTestDataVersion1BlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version1.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
- @Test
-  public void checkTestDataVersion2BlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version2.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
-
- @Test
-  public void checkTestDataVersion3BlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version3.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
- @Test
-  public void checkTestDataVersion4BlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version4.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
- @Test
-  public void checkTestDataVersion1SeekBlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="reqseekversion1.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
- @Test
-  public void checkTestDataTestnet3GenesisBlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
-
- @Test
-  public void checkTestDataTestnet3Version4BlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3version4.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
-
-
- @Test
-  public void checkTestDataMultiNetAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="multinet.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
- 
- @Test
- public void checkTestDataScriptWitnessNetAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
- }
- 
- @Test
- public void checkTestDataScriptWitness2NetAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness2.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
- }
-
-
-
-  @Test
-  public void parseGenesisBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer genesisByteBuffer = bbr.readRawBlock();
-		assertFalse( genesisByteBuffer.isDirect(),"Raw Genesis Block is HeapByteBuffer");
-		assertEquals( 293, genesisByteBuffer.limit(),"Raw Genesis block has a size of 293 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion1BlockAsBitcoinRawBlockHeap()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version1.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version1ByteBuffer = bbr.readRawBlock();
-		assertFalse( version1ByteBuffer.isDirect(),"Random Version 1 Raw Block is HeapByteBuffer");
-		assertEquals( 482, version1ByteBuffer.limit(),"Random Version 1 Raw Block has a size of 482 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion2BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version2.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version2ByteBuffer = bbr.readRawBlock();
-		assertFalse( version2ByteBuffer.isDirect(),"Random Version 2 Raw Block is HeapByteBuffer");
-		assertEquals( 191198, version2ByteBuffer.limit(),"Random Version 2 Raw Block has a size of 191.198 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-
-  @Test
-  public void parseVersion3BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version3.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version3ByteBuffer = bbr.readRawBlock();
-		assertFalse( version3ByteBuffer.isDirect(),"Random Version 3 Raw Block is HeapByteBuffer");
-		assertEquals( 932199, version3ByteBuffer.limit(),"Random Version 3 Raw Block has a size of 932.199 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion4BlockAsBitcoinRawBlockHeap()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version4.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version4ByteBuffer = bbr.readRawBlock();
-		assertFalse( version4ByteBuffer.isDirect(),"Random Version 4 Raw Block is HeapByteBuffer");
-		assertEquals( 998039, version4ByteBuffer.limit(),"Random Version 4 Raw Block has a size of 998.039 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-  public void parseTestNet3GenesisBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		ByteBuffer genesisByteBuffer = bbr.readRawBlock();
-		assertFalse( genesisByteBuffer.isDirect(),"Raw TestNet3 Genesis Block is HeapByteBuffer");
-		assertEquals( 293, genesisByteBuffer.limit(),"Raw TestNet3 Genesis block has a size of 293 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseTestNet3Version4BlockAsBitcoinRawBlockHeap()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3version4.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		ByteBuffer version4ByteBuffer = bbr.readRawBlock();
-		assertFalse( version4ByteBuffer.isDirect(),"Random TestNet3 Version 4 Raw Block is HeapByteBuffer");
-		assertEquals( 749041, version4ByteBuffer.limit(),"Random TestNet3 Version 4 Raw Block has a size of 749.041 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-
-@Test
-  public void parseMultiNetAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="multinet.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.MULTINET_MAGIC,direct);
-		ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
-		assertFalse( firstMultinetByteBuffer.isDirect(),"First MultiNetBlock is HeapByteBuffer");
-		assertEquals( 293, firstMultinetByteBuffer.limit(),"First MultiNetBlock has a size of 293 bytes");
-		ByteBuffer secondMultinetByteBuffer = bbr.readRawBlock();
-		assertFalse( secondMultinetByteBuffer.isDirect(),"Second MultiNetBlock is HeapByteBuffer");
-		assertEquals( 191198, secondMultinetByteBuffer.limit(),"Second MultiNetBlock has a size of 191.198 bytes");
-		ByteBuffer thirdMultinetByteBuffer = bbr.readRawBlock();
-		assertFalse( thirdMultinetByteBuffer.isDirect(),"Third MultiNetBlock is HeapByteBuffer");
-		assertEquals( 749041, thirdMultinetByteBuffer.limit(),"Third MultiNetBlock has a size of 749.041 bytes");
-
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-public void parseScriptWitnessBlockAsBitcoinRawBlockHeap()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-  ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
-		assertFalse( scriptwitnessByteBuffer.isDirect(),"Random ScriptWitness Raw Block is HeapByteBuffer");
-		assertEquals( 999283, scriptwitnessByteBuffer.limit(),"Random ScriptWitness Raw Block has a size of 999283 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
-
-
-@Test
-public void parseScriptWitness2BlockAsBitcoinRawBlockHeap()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-  ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness2.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
-		assertFalse( scriptwitnessByteBuffer.isDirect(),"Random ScriptWitness Raw Block is HeapByteBuffer");
-		assertEquals( 1000039, scriptwitnessByteBuffer.limit(),"Random ScriptWitness Raw Block has a size of 1000039 bytes");		
-		scriptwitnessByteBuffer = bbr.readRawBlock();
-		assertFalse( scriptwitnessByteBuffer.isDirect(),"Random ScriptWitness Raw Block is HeapByteBuffer");
-		assertEquals( 999312, scriptwitnessByteBuffer.limit(),"Random ScriptWitness Raw Block has a size of 999312 bytes");		
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
-
-
-  @Test
-  public void parseGenesisBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer genesisByteBuffer = bbr.readRawBlock();
-		assertTrue( genesisByteBuffer.isDirect(),"Raw Genesis Block is DirectByteBuffer");
-		assertEquals( 293, genesisByteBuffer.limit(),"Raw Genesis Block has a size of 293 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion1BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version1.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version1ByteBuffer = bbr.readRawBlock();
-		assertTrue( version1ByteBuffer.isDirect(),"Random Version 1 Raw Block is DirectByteBuffer");
-		assertEquals( 482, version1ByteBuffer.limit(),"Random Version 1 Raw Block has a size of 482 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion2BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version2.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version2ByteBuffer = bbr.readRawBlock();
-		assertTrue( version2ByteBuffer.isDirect(),"Random Version 2 Raw Block is DirectByteBuffer");
-		assertEquals( 191198, version2ByteBuffer.limit(),"Random Version 2 Raw Block has a size of 191.198 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion3BlockAsBitcoinRawBlockDirect()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version3.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version3ByteBuffer = bbr.readRawBlock();
-		assertTrue( version3ByteBuffer.isDirect(),"Random Version 3 Raw Block is DirectByteBuffer");
-		assertEquals( 932199, version3ByteBuffer.limit(),"Random Version 3 Raw Block has a size of 932.199 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion4BlockAsBitcoinRawBlockDirect()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version4.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version4ByteBuffer = bbr.readRawBlock();
-		assertTrue( version4ByteBuffer.isDirect(),"Random Version 4 Raw Block is DirectByteBuffer");
-		assertEquals( 998039, version4ByteBuffer.limit(),"Random Version 4 Raw Block has a size of 998.039 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-  public void parseTestNet3GenesisBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		ByteBuffer genesisByteBuffer = bbr.readRawBlock();
-		assertTrue( genesisByteBuffer.isDirect(),"Raw TestNet3 Genesis Block is DirectByteBuffer");
-		assertEquals( 293, genesisByteBuffer.limit(),"Raw TestNet3 Genesis block has a size of 293 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseTestNet3Version4BlockAsBitcoinRawBlockDirect()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3version4.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		ByteBuffer version4ByteBuffer = bbr.readRawBlock();
-		assertTrue( version4ByteBuffer.isDirect(),"Random TestNet3 Version 4 Raw Block is DirectByteBuffer");
-		assertEquals( 749041, version4ByteBuffer.limit(),"Random TestNet3  Version 4 Raw Block has a size of 749.041 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-  public void parseMultiNetAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="multinet.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.MULTINET_MAGIC,direct);
-		ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
-		assertTrue( firstMultinetByteBuffer.isDirect(),"First MultiNetBlock is DirectByteBuffer");
-		assertEquals( 293, firstMultinetByteBuffer.limit(),"First MultiNetBlock has a size of 293 bytes");
-		ByteBuffer secondMultinetByteBuffer = bbr.readRawBlock();
-		assertTrue( secondMultinetByteBuffer.isDirect(),"Second MultiNetBlock is DirectByteBuffer");
-		assertEquals( 191198, secondMultinetByteBuffer.limit(),"Second MultiNetBlock has a size of 191.198 bytes");
-		ByteBuffer thirdMultinetByteBuffer = bbr.readRawBlock();
-		assertTrue( thirdMultinetByteBuffer.isDirect(),"Third MultiNetBlock is DirectByteBuffer");
-		assertEquals( 749041, thirdMultinetByteBuffer.limit(),"Third MultiNetBlock has a size of 749.041 bytes");
-
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-public void parseScriptWitnessBlockAsBitcoinRawBlockDirect()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-  ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
-		assertTrue( scriptwitnessByteBuffer.isDirect(),"Random ScriptWitness Raw Block is DirectByteBuffer");
-		assertEquals( 999283, scriptwitnessByteBuffer.limit(),"Random ScriptWitness Raw Block has a size of 999283 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
-
-@Test
-public void parseScriptWitness2BlockAsBitcoinRawBlockDirect()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-  ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness2.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
-		assertTrue( scriptwitnessByteBuffer.isDirect(),"Random ScriptWitness Raw Block is DirectByteBuffer");
-		assertEquals( 1000039, scriptwitnessByteBuffer.limit(),"Random ScriptWitness Raw Block has a size of 1000039 bytes");		
-		scriptwitnessByteBuffer = bbr.readRawBlock();
-		assertTrue( scriptwitnessByteBuffer.isDirect(),"Random ScriptWitness Raw Block is DirectByteBuffer");
-		assertEquals( 999312, scriptwitnessByteBuffer.limit(),"Random ScriptWitness Raw Block has a size of 999312 bytes");		
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
-
-
-
-  @Test
-  public void parseGenesisBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 1, theBitcoinBlock.getTransactions().size(),"Genesis Block must contain exactly one transaction");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Genesis Block must contain exactly one transaction with one input");
-		assertEquals( 77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Genesis Block must contain exactly one transaction with one input and script length 77");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Genesis Block must contain exactly one transaction with one output");
-		assertEquals( BigInteger.valueOf(5000000000L),theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getValue(), "Value must be BigInteger corresponding to 5000000000L");
-		assertEquals( 67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Genesis Block must contain exactly one transaction with one output and script length 67");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-
-  @Test
-  public void parseTestNet3GenesisBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3genesis.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 1, theBitcoinBlock.getTransactions().size(),"TestNet3 Genesis Block must contain exactly one transaction");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"TestNet3 Genesis Block must contain exactly one transaction with one input");
-		assertEquals( 77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"TestNet3 Genesis Block must contain exactly one transaction with one input and script length 77");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"TestNet3 Genesis Block must contain exactly one transaction with one output");
-		assertEquals( 67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"TestNet3 Genesis Block must contain exactly one transaction with one output and script length 67");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion1BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version1.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 2, theBitcoinBlock.getTransactions().size(),"Random Version 1 Block must contain exactly two transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 1 Block must contain exactly two transactions of which the first has one input");
-		assertEquals( 8, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 1 Block must contain exactly two transactions of which the first has one input and script length 8");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 1 Block must contain exactly two transactions of which the first has one output");
-		assertEquals( 67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 1 Block must contain exactly two transactions of which the first has one output and script length 67");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion2BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version2.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 343, theBitcoinBlock.getTransactions().size(),"Random Version 2 Block must contain exactly 343 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
-		assertEquals( 40, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 2 Block must contain exactly 343 transactions of which the first has one input and script length 40");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 2 Block must contain exactly 343 transactions of which the first has one output");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 2 Block must contain exactly 343 transactions of which the first has one output and script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion3BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+    @Test
+    public void checkTestDataGenesisBlockAvailable() {
         ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version3.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 1645, theBitcoinBlock.getTransactions().size(),"Random Version 3 Block must contain exactly 1645 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
-		assertEquals( 49, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 3 Block must contain exactly 1645 transactions of which the first has one input and script length 49");
-		assertEquals( 2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 3 Block must contain exactly 1645 transactions of which the first has two outputs");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 3 Block must contain exactly 1645 transactions of which the first has two output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion4BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-            ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version4.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 936, theBitcoinBlock.getTransactions().size(),"Random Version 4 Block must contain exactly 936 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
-		assertEquals( 4, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 4 Block must contain exactly 936 transactions of which the first has one input and script length 4");
-		assertEquals( 2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 4 Block must contain exactly 936 transactions of which the first has two outputs");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 4 Block must contain exactly 936 transactions of which the first has two output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseTestNet3Version4BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-            ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3version4.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 3299, theBitcoinBlock.getTransactions().size(),"Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
-		assertEquals( 35, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input and script length 35");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one outputs");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-  public void parseMultiNetBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="multinet.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.MULTINET_MAGIC,direct);
-		BitcoinBlock firstBitcoinBlock = bbr.readBlock();
-		assertEquals( 1, firstBitcoinBlock.getTransactions().size(),"First MultiNet Block must contain exactly one transaction");
-		assertEquals( 1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"First MultiNet Block must contain exactly one transaction with one input");
-		assertEquals( 77, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"First MultiNet Block must contain exactly one transaction with one input and script length 77");
-		assertEquals( 1, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"First MultiNet Block must contain exactly one transaction with one output");
-		assertEquals( 67, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"First MultiNet Block must contain exactly one transaction with one output and script length 67");
-		BitcoinBlock secondBitcoinBlock = bbr.readBlock();
-		assertEquals( 343, secondBitcoinBlock.getTransactions().size(),"Second MultiNet Block must contain exactly 343 transactions");
-		assertEquals( 1, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Second MultiNet Block must contain exactly 343 transactions of which the first has one input");
-		assertEquals( 40, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Second MultiNet Block must contain exactly 343 transactions of which the first has one input and script length 40");
-		assertEquals( 1, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Second MultiNet Block must contain exactly 343 transactions of which the first has one output");
-		assertEquals( 25, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Second MultiNet Block must contain exactly 343 transactions of which the first has one output and script length 25");
-		BitcoinBlock thirdBitcoinBlock = bbr.readBlock();
-		assertEquals( 3299, thirdBitcoinBlock.getTransactions().size(),"Third MultiNet Block must contain exactly 3299 transactions");
-		assertEquals( 1, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Third MultiNet Block must contain exactly 3299 transactions of which the first has one input");
-		assertEquals( 35, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Third MultiNet Block must contain exactly 3299 transactions of which the first has one input and script length 35");
-		assertEquals( 1, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Third MultiNet Block must contain exactly 3299 transactions of which the first has one outputs");
-		assertEquals( 25, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Third MultiNet Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-public void parseScriptWitnessBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 470, theBitcoinBlock.getTransactions().size(),"Random ScriptWitness Block must contain exactly 470 transactions");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
+        String fileName = "genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
 
 
-@Test
-public void parseScriptWitness2BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness2.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 2191, theBitcoinBlock.getTransactions().size(),"First random ScriptWitness Block must contain exactly 2191 transactions");
-		theBitcoinBlock = bbr.readBlock();
-		assertEquals( 2508, theBitcoinBlock.getTransactions().size(),"Second random ScriptWitness Block must contain exactly 2508 transactions");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
-
-  @Test
-  public void parseGenesisBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 1, theBitcoinBlock.getTransactions().size(),"Genesis Block must contain exactly one transaction");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Genesis Block must contain exactly one transaction with one input");
-		assertEquals( 77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Genesis Block must contain exactly one transaction with one input and script length 77");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Genesis Block must contain exactly one transaction with one output");
-		assertEquals( 67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Genesis Block must contain exactly one transaction with one output and script length 67");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-
-  @Test
-  public void parseTestNet3GenesisBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3genesis.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 1, theBitcoinBlock.getTransactions().size(),"TestNet3 Genesis Block must contain exactly one transaction");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"TestNet3 Genesis Block must contain exactly one transaction with one input");
-		assertEquals( 77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"TestNet3 Genesis Block must contain exactly one transaction with one input and script length 77");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"TestNet3 Genesis Block must contain exactly one transaction with one output");
-		assertEquals( 67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"TestNet3 Genesis Block must contain exactly one transaction with one output and script length 67");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-
-  @Test
-  public void parseVersion1BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version1.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 2, theBitcoinBlock.getTransactions().size(),"Random Version 1 Block must contain exactly two transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 1 Block must contain exactly two transactions of which the first has one input");
-		assertEquals( 8, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 1 Block must contain exactly two transactions of which the first has one input and script length 8");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 1 Block must contain exactly two transactions of which the first has one output");
-		assertEquals( 67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 1 Block must contain exactly two transactions of which the first has one output and script length 67");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion2BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-      	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version2.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 343, theBitcoinBlock.getTransactions().size(),"Random Version 2 Block must contain exactly 343 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
-		assertEquals( 40, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 2 Block must contain exactly 343 transactions of which the first has one input and script length 40");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 2 Block must contain exactly 343 transactions of which the first has one output");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 2 Block must contain exactly 343 transactions of which the first has one output and script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion3BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-            ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version3.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 1645, theBitcoinBlock.getTransactions().size(),"Random Version 3 Block must contain exactly 1645 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
-		assertEquals( 49, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 3 Block must contain exactly 1645 transactions of which the first has one input and script length 49");
-		assertEquals( 2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 3 Block must contain exactly 1645 transactions of which the first has two outputs");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 3 Block must contain exactly 1645 transactions of which the first has two output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion4BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+    @Test
+    public void checkTestDataVersion1BlockAvailable() {
         ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version4.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 936, theBitcoinBlock.getTransactions().size(),"Random Version 4 Block must contain exactly 936 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
-		assertEquals( 4, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 4 Block must contain exactly 936 transactions of which the first has one input and script length 4");
-		assertEquals( 2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 4 Block must contain exactly 936 transactions of which the first has two outputs");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 4 Block must contain exactly 936 transactions of which the first has two output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
+        String fileName = "version1.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    @Test
+    public void checkTestDataVersion2BlockAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version2.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
 
 
-  @Test
-  public void parseTestNet3Version4BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-            ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3version4.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 3299, theBitcoinBlock.getTransactions().size(),"Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
-		assertEquals( 35, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input and script length 35");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one outputs");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
+    @Test
+    public void checkTestDataVersion3BlockAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version3.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
 
-@Test
-  public void parseMultiNetBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="multinet.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.MULTINET_MAGIC,direct);
-		BitcoinBlock firstBitcoinBlock = bbr.readBlock();
-		assertEquals( 1, firstBitcoinBlock.getTransactions().size(),"First MultiNet Block must contain exactly one transaction");
-		assertEquals( 1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"First MultiNet Block must contain exactly one transaction with one input");
-		assertEquals( 77, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"First MultiNet Block must contain exactly one transaction with one input and script length 77");
-		assertEquals( 1, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"First MultiNet Block must contain exactly one transaction with one output");
-		assertEquals( 67, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"First MultiNet Block must contain exactly one transaction with one output and script length 67");
-		BitcoinBlock secondBitcoinBlock = bbr.readBlock();
-		assertEquals( 343, secondBitcoinBlock.getTransactions().size(),"Second MultiNet Block must contain exactly 343 transactions");
-		assertEquals( 1, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Second MultiNet Block must contain exactly 343 transactions of which the first has one input");
-		assertEquals( 40, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Second MultiNet Block must contain exactly 343 transactions of which the first has one input and script length 40");
-		assertEquals( 1, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Second MultiNet Block must contain exactly 343 transactions of which the first has one output");
-		assertEquals( 25, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Second MultiNet Block must contain exactly 343 transactions of which the first has one output and script length 25");
-		BitcoinBlock thirdBitcoinBlock = bbr.readBlock();
-		assertEquals( 3299, thirdBitcoinBlock.getTransactions().size(),"Third MultiNet Block must contain exactly 3299 transactions");
-		assertEquals( 1, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Third MultiNet Block must contain exactly 3299 transactions of which the first has one input");
-		assertEquals( 35, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Third MultiNet Block must contain exactly 3299 transactions of which the first has one input and script length 35");
-		assertEquals( 1, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Third MultiNet Block must contain exactly 3299 transactions of which the first has one outputs");
-		assertEquals( 25, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Third MultiNet Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
+    @Test
+    public void checkTestDataVersion4BlockAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version4.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    @Test
+    public void checkTestDataVersion1SeekBlockAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "reqseekversion1.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    @Test
+    public void checkTestDataTestnet3GenesisBlockAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
 
 
-@Test
-public void parseScriptWitnessBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 470, theBitcoinBlock.getTransactions().size(),"Random ScriptWitness Block must contain exactly 470 transactions");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
+    @Test
+    public void checkTestDataTestnet3Version4BlockAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3version4.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+
+    @Test
+    public void checkTestDataMultiNetAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "multinet.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    @Test
+    public void checkTestDataScriptWitnessNetAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    @Test
+    public void checkTestDataScriptWitness2NetAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness2.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+
+    @Test
+    public void parseGenesisBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertFalse(genesisByteBuffer.isDirect(), "Raw Genesis Block is HeapByteBuffer");
+            assertEquals(293, genesisByteBuffer.limit(), "Raw Genesis block has a size of 293 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion1BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version1.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version1ByteBuffer = bbr.readRawBlock();
+            assertFalse(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block is HeapByteBuffer");
+            assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block has a size of 482 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion2BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version2.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version2ByteBuffer = bbr.readRawBlock();
+            assertFalse(version2ByteBuffer.isDirect(), "Random Version 2 Raw Block is HeapByteBuffer");
+            assertEquals(191198, version2ByteBuffer.limit(), "Random Version 2 Raw Block has a size of 191.198 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseVersion3BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version3.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version3ByteBuffer = bbr.readRawBlock();
+            assertFalse(version3ByteBuffer.isDirect(), "Random Version 3 Raw Block is HeapByteBuffer");
+            assertEquals(932199, version3ByteBuffer.limit(), "Random Version 3 Raw Block has a size of 932.199 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion4BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version4.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version4ByteBuffer = bbr.readRawBlock();
+            assertFalse(version4ByteBuffer.isDirect(), "Random Version 4 Raw Block is HeapByteBuffer");
+            assertEquals(998039, version4ByteBuffer.limit(), "Random Version 4 Raw Block has a size of 998.039 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseTestNet3GenesisBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertFalse(genesisByteBuffer.isDirect(), "Raw TestNet3 Genesis Block is HeapByteBuffer");
+            assertEquals(293, genesisByteBuffer.limit(), "Raw TestNet3 Genesis block has a size of 293 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseTestNet3Version4BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3version4.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            ByteBuffer version4ByteBuffer = bbr.readRawBlock();
+            assertFalse(version4ByteBuffer.isDirect(), "Random TestNet3 Version 4 Raw Block is HeapByteBuffer");
+            assertEquals(749041, version4ByteBuffer.limit(), "Random TestNet3 Version 4 Raw Block has a size of 749.041 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseMultiNetAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "multinet.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
+            assertFalse(firstMultinetByteBuffer.isDirect(), "First MultiNetBlock is HeapByteBuffer");
+            assertEquals(293, firstMultinetByteBuffer.limit(), "First MultiNetBlock has a size of 293 bytes");
+            ByteBuffer secondMultinetByteBuffer = bbr.readRawBlock();
+            assertFalse(secondMultinetByteBuffer.isDirect(), "Second MultiNetBlock is HeapByteBuffer");
+            assertEquals(191198, secondMultinetByteBuffer.limit(), "Second MultiNetBlock has a size of 191.198 bytes");
+            ByteBuffer thirdMultinetByteBuffer = bbr.readRawBlock();
+            assertFalse(thirdMultinetByteBuffer.isDirect(), "Third MultiNetBlock is HeapByteBuffer");
+            assertEquals(749041, thirdMultinetByteBuffer.limit(), "Third MultiNetBlock has a size of 749.041 bytes");
+
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseScriptWitnessBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
+            assertFalse(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is HeapByteBuffer");
+            assertEquals(999283, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999283 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseScriptWitness2BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness2.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
+            assertFalse(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is HeapByteBuffer");
+            assertEquals(1000039, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 1000039 bytes");
+            scriptwitnessByteBuffer = bbr.readRawBlock();
+            assertFalse(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is HeapByteBuffer");
+            assertEquals(999312, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999312 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseGenesisBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertTrue(genesisByteBuffer.isDirect(), "Raw Genesis Block is DirectByteBuffer");
+            assertEquals(293, genesisByteBuffer.limit(), "Raw Genesis Block has a size of 293 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseGenesisBlockTestTime() throws IOException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertTrue(genesisByteBuffer.isDirect(), "Raw Genesis Block is DirectByteBuffer");
+            assertEquals(293, genesisByteBuffer.limit(), "Raw Genesis Block has a size of 293 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion1BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version1.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version1ByteBuffer = bbr.readRawBlock();
+            assertTrue(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block is DirectByteBuffer");
+            assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block has a size of 482 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion2BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version2.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version2ByteBuffer = bbr.readRawBlock();
+            assertTrue(version2ByteBuffer.isDirect(), "Random Version 2 Raw Block is DirectByteBuffer");
+            assertEquals(191198, version2ByteBuffer.limit(), "Random Version 2 Raw Block has a size of 191.198 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion3BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version3.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version3ByteBuffer = bbr.readRawBlock();
+            assertTrue(version3ByteBuffer.isDirect(), "Random Version 3 Raw Block is DirectByteBuffer");
+            assertEquals(932199, version3ByteBuffer.limit(), "Random Version 3 Raw Block has a size of 932.199 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion4BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version4.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version4ByteBuffer = bbr.readRawBlock();
+            assertTrue(version4ByteBuffer.isDirect(), "Random Version 4 Raw Block is DirectByteBuffer");
+            assertEquals(998039, version4ByteBuffer.limit(), "Random Version 4 Raw Block has a size of 998.039 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseTestNet3GenesisBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertTrue(genesisByteBuffer.isDirect(), "Raw TestNet3 Genesis Block is DirectByteBuffer");
+            assertEquals(293, genesisByteBuffer.limit(), "Raw TestNet3 Genesis block has a size of 293 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseTestNet3Version4BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3version4.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            ByteBuffer version4ByteBuffer = bbr.readRawBlock();
+            assertTrue(version4ByteBuffer.isDirect(), "Random TestNet3 Version 4 Raw Block is DirectByteBuffer");
+            assertEquals(749041, version4ByteBuffer.limit(), "Random TestNet3  Version 4 Raw Block has a size of 749.041 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseMultiNetAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "multinet.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
+            assertTrue(firstMultinetByteBuffer.isDirect(), "First MultiNetBlock is DirectByteBuffer");
+            assertEquals(293, firstMultinetByteBuffer.limit(), "First MultiNetBlock has a size of 293 bytes");
+            ByteBuffer secondMultinetByteBuffer = bbr.readRawBlock();
+            assertTrue(secondMultinetByteBuffer.isDirect(), "Second MultiNetBlock is DirectByteBuffer");
+            assertEquals(191198, secondMultinetByteBuffer.limit(), "Second MultiNetBlock has a size of 191.198 bytes");
+            ByteBuffer thirdMultinetByteBuffer = bbr.readRawBlock();
+            assertTrue(thirdMultinetByteBuffer.isDirect(), "Third MultiNetBlock is DirectByteBuffer");
+            assertEquals(749041, thirdMultinetByteBuffer.limit(), "Third MultiNetBlock has a size of 749.041 bytes");
+
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseScriptWitnessBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
+            assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
+            assertEquals(999283, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999283 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseScriptWitness2BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness2.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
+            assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
+            assertEquals(1000039, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 1000039 bytes");
+            scriptwitnessByteBuffer = bbr.readRawBlock();
+            assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
+            assertEquals(999312, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999312 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseGenesisBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(1, theBitcoinBlock.getTransactions().size(), "Genesis Block must contain exactly one transaction");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Genesis Block must contain exactly one transaction with one input");
+            assertEquals(77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Genesis Block must contain exactly one transaction with one input and script length 77");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Genesis Block must contain exactly one transaction with one output");
+            assertEquals(BigInteger.valueOf(5000000000L), theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getValue(), "Value must be BigInteger corresponding to 5000000000L");
+            assertEquals(67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Genesis Block must contain exactly one transaction with one output and script length 67");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseTestNet3GenesisBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3genesis.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(1, theBitcoinBlock.getTransactions().size(), "TestNet3 Genesis Block must contain exactly one transaction");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one input");
+            assertEquals(77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "TestNet3 Genesis Block must contain exactly one transaction with one input and script length 77");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one output");
+            assertEquals(67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "TestNet3 Genesis Block must contain exactly one transaction with one output and script length 67");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion1BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version1.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(2, theBitcoinBlock.getTransactions().size(), "Random Version 1 Block must contain exactly two transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one input");
+            assertEquals(8, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 1 Block must contain exactly two transactions of which the first has one input and script length 8");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one output");
+            assertEquals(67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 1 Block must contain exactly two transactions of which the first has one output and script length 67");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion2BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version2.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(343, theBitcoinBlock.getTransactions().size(), "Random Version 2 Block must contain exactly 343 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
+            assertEquals(40, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 2 Block must contain exactly 343 transactions of which the first has one input and script length 40");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one output");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 2 Block must contain exactly 343 transactions of which the first has one output and script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion3BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version3.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(1645, theBitcoinBlock.getTransactions().size(), "Random Version 3 Block must contain exactly 1645 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
+            assertEquals(49, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input and script length 49");
+            assertEquals(2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has two outputs");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 3 Block must contain exactly 1645 transactions of which the first has two output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion4BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version4.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(936, theBitcoinBlock.getTransactions().size(), "Random Version 4 Block must contain exactly 936 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
+            assertEquals(4, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 4 Block must contain exactly 936 transactions of which the first has one input and script length 4");
+            assertEquals(2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has two outputs");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 4 Block must contain exactly 936 transactions of which the first has two output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseTestNet3Version4BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3version4.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(3299, theBitcoinBlock.getTransactions().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
+            assertEquals(35, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input and script length 35");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one outputs");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseMultiNetBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "multinet.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            BitcoinBlock firstBitcoinBlock = bbr.readBlock();
+            assertEquals(1, firstBitcoinBlock.getTransactions().size(), "First MultiNet Block must contain exactly one transaction");
+            assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "First MultiNet Block must contain exactly one transaction with one input");
+            assertEquals(77, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "First MultiNet Block must contain exactly one transaction with one input and script length 77");
+            assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "First MultiNet Block must contain exactly one transaction with one output");
+            assertEquals(67, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "First MultiNet Block must contain exactly one transaction with one output and script length 67");
+            BitcoinBlock secondBitcoinBlock = bbr.readBlock();
+            assertEquals(343, secondBitcoinBlock.getTransactions().size(), "Second MultiNet Block must contain exactly 343 transactions");
+            assertEquals(1, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Second MultiNet Block must contain exactly 343 transactions of which the first has one input");
+            assertEquals(40, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Second MultiNet Block must contain exactly 343 transactions of which the first has one input and script length 40");
+            assertEquals(1, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Second MultiNet Block must contain exactly 343 transactions of which the first has one output");
+            assertEquals(25, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Second MultiNet Block must contain exactly 343 transactions of which the first has one output and script length 25");
+            BitcoinBlock thirdBitcoinBlock = bbr.readBlock();
+            assertEquals(3299, thirdBitcoinBlock.getTransactions().size(), "Third MultiNet Block must contain exactly 3299 transactions");
+            assertEquals(1, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Third MultiNet Block must contain exactly 3299 transactions of which the first has one input");
+            assertEquals(35, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Third MultiNet Block must contain exactly 3299 transactions of which the first has one input and script length 35");
+            assertEquals(1, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Third MultiNet Block must contain exactly 3299 transactions of which the first has one outputs");
+            assertEquals(25, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Third MultiNet Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseScriptWitnessBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(470, theBitcoinBlock.getTransactions().size(), "Random ScriptWitness Block must contain exactly 470 transactions");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseScriptWitness2BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness2.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(2191, theBitcoinBlock.getTransactions().size(), "First random ScriptWitness Block must contain exactly 2191 transactions");
+            theBitcoinBlock = bbr.readBlock();
+            assertEquals(2508, theBitcoinBlock.getTransactions().size(), "Second random ScriptWitness Block must contain exactly 2508 transactions");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseGenesisBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(1, theBitcoinBlock.getTransactions().size(), "Genesis Block must contain exactly one transaction");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Genesis Block must contain exactly one transaction with one input");
+            assertEquals(77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Genesis Block must contain exactly one transaction with one input and script length 77");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Genesis Block must contain exactly one transaction with one output");
+            assertEquals(67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Genesis Block must contain exactly one transaction with one output and script length 67");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseTestNet3GenesisBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3genesis.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(1, theBitcoinBlock.getTransactions().size(), "TestNet3 Genesis Block must contain exactly one transaction");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one input");
+            assertEquals(77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "TestNet3 Genesis Block must contain exactly one transaction with one input and script length 77");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one output");
+            assertEquals(67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "TestNet3 Genesis Block must contain exactly one transaction with one output and script length 67");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseVersion1BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version1.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(2, theBitcoinBlock.getTransactions().size(), "Random Version 1 Block must contain exactly two transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one input");
+            assertEquals(8, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 1 Block must contain exactly two transactions of which the first has one input and script length 8");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one output");
+            assertEquals(67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 1 Block must contain exactly two transactions of which the first has one output and script length 67");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion2BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version2.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(343, theBitcoinBlock.getTransactions().size(), "Random Version 2 Block must contain exactly 343 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
+            assertEquals(40, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 2 Block must contain exactly 343 transactions of which the first has one input and script length 40");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one output");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 2 Block must contain exactly 343 transactions of which the first has one output and script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion3BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version3.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(1645, theBitcoinBlock.getTransactions().size(), "Random Version 3 Block must contain exactly 1645 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
+            assertEquals(49, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input and script length 49");
+            assertEquals(2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has two outputs");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 3 Block must contain exactly 1645 transactions of which the first has two output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion4BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version4.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(936, theBitcoinBlock.getTransactions().size(), "Random Version 4 Block must contain exactly 936 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
+            assertEquals(4, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 4 Block must contain exactly 936 transactions of which the first has one input and script length 4");
+            assertEquals(2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has two outputs");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 4 Block must contain exactly 936 transactions of which the first has two output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseTestNet3Version4BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3version4.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(3299, theBitcoinBlock.getTransactions().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
+            assertEquals(35, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input and script length 35");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one outputs");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseMultiNetBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "multinet.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            BitcoinBlock firstBitcoinBlock = bbr.readBlock();
+            assertEquals(1, firstBitcoinBlock.getTransactions().size(), "First MultiNet Block must contain exactly one transaction");
+            assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "First MultiNet Block must contain exactly one transaction with one input");
+            assertEquals(77, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "First MultiNet Block must contain exactly one transaction with one input and script length 77");
+            assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "First MultiNet Block must contain exactly one transaction with one output");
+            assertEquals(67, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "First MultiNet Block must contain exactly one transaction with one output and script length 67");
+            BitcoinBlock secondBitcoinBlock = bbr.readBlock();
+            assertEquals(343, secondBitcoinBlock.getTransactions().size(), "Second MultiNet Block must contain exactly 343 transactions");
+            assertEquals(1, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Second MultiNet Block must contain exactly 343 transactions of which the first has one input");
+            assertEquals(40, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Second MultiNet Block must contain exactly 343 transactions of which the first has one input and script length 40");
+            assertEquals(1, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Second MultiNet Block must contain exactly 343 transactions of which the first has one output");
+            assertEquals(25, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Second MultiNet Block must contain exactly 343 transactions of which the first has one output and script length 25");
+            BitcoinBlock thirdBitcoinBlock = bbr.readBlock();
+            assertEquals(3299, thirdBitcoinBlock.getTransactions().size(), "Third MultiNet Block must contain exactly 3299 transactions");
+            assertEquals(1, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Third MultiNet Block must contain exactly 3299 transactions of which the first has one input");
+            assertEquals(35, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Third MultiNet Block must contain exactly 3299 transactions of which the first has one input and script length 35");
+            assertEquals(1, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Third MultiNet Block must contain exactly 3299 transactions of which the first has one outputs");
+            assertEquals(25, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Third MultiNet Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseScriptWitnessBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(470, theBitcoinBlock.getTransactions().size(), "Random ScriptWitness Block must contain exactly 470 transactions");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseScriptWitness2BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness2.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(2191, theBitcoinBlock.getTransactions().size(), "First random ScriptWitness Block must contain exactly 2191 transactions");
+            theBitcoinBlock = bbr.readBlock();
+            assertEquals(2508, theBitcoinBlock.getTransactions().size(), "Second random ScriptWitness Block must contain exactly 2508 transactions");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void seekBlockStartHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "reqseekversion1.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr.seekBlockStart();
+            ByteBuffer version1ByteBuffer = bbr.readRawBlock();
+            assertFalse(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block (requiring seek) is HeapByteBuffer");
+            assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block (requiring seek) has a size of 482 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void seekBlockStartDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "reqseekversion1.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr.seekBlockStart();
+            ByteBuffer version1ByteBuffer = bbr.readRawBlock();
+            assertTrue(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block (requiring seek) is DirectByteBuffer");
+            assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block (requiring seek) has a size of 482 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void getKeyFromRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertFalse(genesisByteBuffer.isDirect(), "Raw Genesis Block is HeapByteBuffer");
+            byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
+            assertEquals(64, key.length, "Raw Genesis Block Key should have a size of 64 bytes");
+            byte[] comparatorKey = new byte[]{(byte) 0x3B, (byte) 0xA3, (byte) 0xED, (byte) 0xFD, (byte) 0x7A, (byte) 0x7B, (byte) 0x12, (byte) 0xB2, (byte) 0x7A, (byte) 0xC7, (byte) 0x2C, (byte) 0x3E, (byte) 0x67, (byte) 0x76, (byte) 0x8F, (byte) 0x61, (byte) 0x7F, (byte) 0xC8, (byte) 0x1B, (byte) 0xC3, (byte) 0x88, (byte) 0x8A, (byte) 0x51, (byte) 0x32, (byte) 0x3A, (byte) 0x9F, (byte) 0xB8, (byte) 0xAA, (byte) 0x4B, (byte) 0x1E, (byte) 0x5E, (byte) 0x4A, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00};
+            assertArrayEquals(comparatorKey, key, "Raw Genesis Block Key is equivalent to comparator key");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void getKeyFromRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertTrue(genesisByteBuffer.isDirect(), "Raw Genesis Block is DirectByteBuffer");
+            byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
+            assertEquals(64, key.length, "Raw Genesis Block Key should have a size of 64 bytes");
+            byte[] comparatorKey = new byte[]{(byte) 0x3B, (byte) 0xA3, (byte) 0xED, (byte) 0xFD, (byte) 0x7A, (byte) 0x7B, (byte) 0x12, (byte) 0xB2, (byte) 0x7A, (byte) 0xC7, (byte) 0x2C, (byte) 0x3E, (byte) 0x67, (byte) 0x76, (byte) 0x8F, (byte) 0x61, (byte) 0x7F, (byte) 0xC8, (byte) 0x1B, (byte) 0xC3, (byte) 0x88, (byte) 0x8A, (byte) 0x51, (byte) 0x32, (byte) 0x3A, (byte) 0x9F, (byte) 0xB8, (byte) 0xAA, (byte) 0x4B, (byte) 0x1E, (byte) 0x5E, (byte) 0x4A, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00};
+            assertArrayEquals(comparatorKey, key, "Raw Genesis Block Key is equivalent to comparator key");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
 }
-
-@Test
-public void parseScriptWitness2BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness2.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 2191, theBitcoinBlock.getTransactions().size(),"First random ScriptWitness Block must contain exactly 2191 transactions");
-		theBitcoinBlock = bbr.readBlock();
-		assertEquals( 2508, theBitcoinBlock.getTransactions().size(),"Second random ScriptWitness Block must contain exactly 2508 transactions");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
-
-  @Test
-  public void seekBlockStartHeap()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-     ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="reqseekversion1.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		bbr.seekBlockStart();
-		ByteBuffer version1ByteBuffer = bbr.readRawBlock();
-		assertFalse( version1ByteBuffer.isDirect(),"Random Version 1 Raw Block (requiring seek) is HeapByteBuffer");
-		assertEquals( 482, version1ByteBuffer.limit(),"Random Version 1 Raw Block (requiring seek) has a size of 482 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
- @Test
-  public void seekBlockStartDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException  {
-         ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="reqseekversion1.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		bbr.seekBlockStart();
-		ByteBuffer version1ByteBuffer = bbr.readRawBlock();
-		assertTrue( version1ByteBuffer.isDirect(),"Random Version 1 Raw Block (requiring seek) is DirectByteBuffer");
-		assertEquals( 482, version1ByteBuffer.limit(),"Random Version 1 Raw Block (requiring seek) has a size of 482 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
- @Test
-  public void getKeyFromRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer genesisByteBuffer = bbr.readRawBlock();
-		assertFalse( genesisByteBuffer.isDirect(),"Raw Genesis Block is HeapByteBuffer");
-		byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
-		assertEquals( 64, key.length,"Raw Genesis Block Key should have a size of 64 bytes");
-		byte[] comparatorKey = new byte[]{(byte)0x3B,(byte)0xA3,(byte)0xED,(byte)0xFD,(byte)0x7A,(byte)0x7B,(byte)0x12,(byte)0xB2,(byte)0x7A,(byte)0xC7,(byte)0x2C,(byte)0x3E,(byte)0x67,(byte)0x76,(byte)0x8F,(byte)0x61,(byte)0x7F,(byte)0xC8,(byte)0x1B,(byte)0xC3,(byte)0x88,(byte)0x8A,(byte)0x51,(byte)0x32,(byte)0x3A,(byte)0x9F,(byte)0xB8,(byte)0xAA,(byte)0x4B,(byte)0x1E,(byte)0x5E,(byte)0x4A,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00};
-		assertArrayEquals( comparatorKey, key,"Raw Genesis Block Key is equivalent to comparator key");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
- @Test
-  public void getKeyFromRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer genesisByteBuffer = bbr.readRawBlock();
-		assertTrue( genesisByteBuffer.isDirect(),"Raw Genesis Block is DirectByteBuffer");
-		byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
-		assertEquals( 64, key.length,"Raw Genesis Block Key should have a size of 64 bytes");
-		byte[] comparatorKey = new byte[]{(byte)0x3B,(byte)0xA3,(byte)0xED,(byte)0xFD,(byte)0x7A,(byte)0x7B,(byte)0x12,(byte)0xB2,(byte)0x7A,(byte)0xC7,(byte)0x2C,(byte)0x3E,(byte)0x67,(byte)0x76,(byte)0x8F,(byte)0x61,(byte)0x7F,(byte)0xC8,(byte)0x1B,(byte)0xC3,(byte)0x88,(byte)0x8A,(byte)0x51,(byte)0x32,(byte)0x3A,(byte)0x9F,(byte)0xB8,(byte)0xAA,(byte)0x4B,(byte)0x1E,(byte)0x5E,(byte)0x4A,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00};
-		assertArrayEquals( comparatorKey, key,"Raw Genesis Block Key is equivalent to comparator key");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-	}
-
-
-
-} 
 
 

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
@@ -1,18 +1,18 @@
-/**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+/*
+ Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 package org.zuinnote.hadoop.bitcoin.format.common;
 
@@ -31,7 +31,6 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 
 import org.junit.jupiter.api.Test;
-import org.zuinnote.hadoop.bitcoin.format.common.BitcoinBlockReader;
 import org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException;
 
 

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
@@ -33,7 +33,6 @@ import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-
 public class BitcoinFormatReaderTest {
 
     static final int DEFAULT_BUFFERSIZE = 64 * 1024;
@@ -43,21 +42,10 @@ public class BitcoinFormatReaderTest {
     private static final byte[][] MULTINET_MAGIC = {{(byte) 0xF9, (byte) 0xBE, (byte) 0xB4, (byte) 0xD9}, {(byte) 0x0B, (byte) 0x11, (byte) 0x09, (byte) 0x07}};
 
     @Test
-    public void checkTestDataAvailable() {
-        String[] testFiles = new String[] {
-                "genesis.blk", "version1.blk", "version2.blk", "version3.blk", "version4.blk",
-                "reqseekversion1.blk", "testnet3genesis.blk", "testnet3version4.blk", "testnet3version4.blk",
-                "multinet.blk", "scriptwitness.blk", "scriptwitness2.blk"};
-        for(String fileName: testFiles) {
-            assertTestFileAvailable(fileName);
-        }
-    }
-
-    @Test
     public void parseGenesisBlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("genesis.blk", false);
+            bbr = assertBlockAvailable("genesis.blk", false);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertFalse(genesisByteBuffer.isDirect(), "Raw Genesis Block is HeapByteBuffer");
             assertEquals(293, genesisByteBuffer.limit(), "Raw Genesis block has a size of 293 bytes");
@@ -71,7 +59,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion1BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version1.blk", false);
+            bbr = assertBlockAvailable("version1.blk", false);
             ByteBuffer version1ByteBuffer = bbr.readRawBlock();
             assertFalse(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block is HeapByteBuffer");
             assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block has a size of 482 bytes");
@@ -85,7 +73,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion2BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version2.blk", false);
+            bbr = assertBlockAvailable("version2.blk", false);
             ByteBuffer version2ByteBuffer = bbr.readRawBlock();
             assertFalse(version2ByteBuffer.isDirect(), "Random Version 2 Raw Block is HeapByteBuffer");
             assertEquals(191198, version2ByteBuffer.limit(), "Random Version 2 Raw Block has a size of 191.198 bytes");
@@ -99,7 +87,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion3BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version3.blk", false);
+            bbr = assertBlockAvailable("version3.blk", false);
             ByteBuffer version3ByteBuffer = bbr.readRawBlock();
             assertFalse(version3ByteBuffer.isDirect(), "Random Version 3 Raw Block is HeapByteBuffer");
             assertEquals(932199, version3ByteBuffer.limit(), "Random Version 3 Raw Block has a size of 932.199 bytes");
@@ -113,7 +101,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion4BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version4.blk", false);
+            bbr = assertBlockAvailable("version4.blk", false);
             ByteBuffer version4ByteBuffer = bbr.readRawBlock();
             assertFalse(version4ByteBuffer.isDirect(), "Random Version 4 Raw Block is HeapByteBuffer");
             assertEquals(998039, version4ByteBuffer.limit(), "Random Version 4 Raw Block has a size of 998.039 bytes");
@@ -127,7 +115,7 @@ public class BitcoinFormatReaderTest {
     public void parseTestNet3GenesisBlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("testnet3genesis.blk", false, TESTNET3_MAGIC);
+            bbr = assertBlockAvailable("testnet3genesis.blk", false, TESTNET3_MAGIC);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertFalse(genesisByteBuffer.isDirect(), "Raw TestNet3 Genesis Block is HeapByteBuffer");
             assertEquals(293, genesisByteBuffer.limit(), "Raw TestNet3 Genesis block has a size of 293 bytes");
@@ -141,7 +129,7 @@ public class BitcoinFormatReaderTest {
     public void parseTestNet3Version4BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("testnet3version4.blk", false, TESTNET3_MAGIC);
+            bbr = assertBlockAvailable("testnet3version4.blk", false, TESTNET3_MAGIC);
             ByteBuffer version4ByteBuffer = bbr.readRawBlock();
             assertFalse(version4ByteBuffer.isDirect(), "Random TestNet3 Version 4 Raw Block is HeapByteBuffer");
             assertEquals(749041, version4ByteBuffer.limit(), "Random TestNet3 Version 4 Raw Block has a size of 749.041 bytes");
@@ -155,7 +143,7 @@ public class BitcoinFormatReaderTest {
     public void parseMultiNetAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("multinet.blk", false, MULTINET_MAGIC);
+            bbr = assertBlockAvailable("multinet.blk", false, MULTINET_MAGIC);
             ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
             assertFalse(firstMultinetByteBuffer.isDirect(), "First MultiNetBlock is HeapByteBuffer");
             assertEquals(293, firstMultinetByteBuffer.limit(), "First MultiNetBlock has a size of 293 bytes");
@@ -175,7 +163,7 @@ public class BitcoinFormatReaderTest {
     public void parseScriptWitnessBlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("scriptwitness.blk", false);
+            bbr = assertBlockAvailable("scriptwitness.blk", false);
             ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
             assertFalse(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is HeapByteBuffer");
             assertEquals(999283, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999283 bytes");
@@ -189,7 +177,7 @@ public class BitcoinFormatReaderTest {
     public void parseScriptWitness2BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("scriptwitness2.blk", false);
+            bbr = assertBlockAvailable("scriptwitness2.blk", false);
             ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
             assertFalse(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is HeapByteBuffer");
             assertEquals(1000039, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 1000039 bytes");
@@ -206,7 +194,7 @@ public class BitcoinFormatReaderTest {
     public void parseGenesisBlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = genesisBlockReader(true);
+            bbr = assertBlockAvailable("genesis.blk", true);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertTrue(genesisByteBuffer.isDirect(), "Raw Genesis Block is DirectByteBuffer");
             assertEquals(293, genesisByteBuffer.limit(), "Raw Genesis Block has a size of 293 bytes");
@@ -238,7 +226,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion1BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version1.blk", true);
+            bbr = assertBlockAvailable("version1.blk", true);
             ByteBuffer version1ByteBuffer = bbr.readRawBlock();
             assertTrue(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block is DirectByteBuffer");
             assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block has a size of 482 bytes");
@@ -252,7 +240,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion2BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version2.blk", true);
+            bbr = assertBlockAvailable("version2.blk", true);
             ByteBuffer version2ByteBuffer = bbr.readRawBlock();
             assertTrue(version2ByteBuffer.isDirect(), "Random Version 2 Raw Block is DirectByteBuffer");
             assertEquals(191198, version2ByteBuffer.limit(), "Random Version 2 Raw Block has a size of 191.198 bytes");
@@ -266,7 +254,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion3BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version3.blk", true);
+            bbr = assertBlockAvailable("version3.blk", true);
             ByteBuffer version3ByteBuffer = bbr.readRawBlock();
             assertTrue(version3ByteBuffer.isDirect(), "Random Version 3 Raw Block is DirectByteBuffer");
             assertEquals(932199, version3ByteBuffer.limit(), "Random Version 3 Raw Block has a size of 932.199 bytes");
@@ -280,7 +268,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion4BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version4.blk", true);
+            bbr = assertBlockAvailable("version4.blk", true);
             ByteBuffer version4ByteBuffer = bbr.readRawBlock();
             assertTrue(version4ByteBuffer.isDirect(), "Random Version 4 Raw Block is DirectByteBuffer");
             assertEquals(998039, version4ByteBuffer.limit(), "Random Version 4 Raw Block has a size of 998.039 bytes");
@@ -294,7 +282,7 @@ public class BitcoinFormatReaderTest {
     public void parseTestNet3GenesisBlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("testnet3genesis.blk", true, TESTNET3_MAGIC);
+            bbr = assertBlockAvailable("testnet3genesis.blk", true, TESTNET3_MAGIC);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertTrue(genesisByteBuffer.isDirect(), "Raw TestNet3 Genesis Block is DirectByteBuffer");
             assertEquals(293, genesisByteBuffer.limit(), "Raw TestNet3 Genesis block has a size of 293 bytes");
@@ -308,7 +296,7 @@ public class BitcoinFormatReaderTest {
     public void parseTestNet3Version4BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("testnet3version4.blk", true, TESTNET3_MAGIC);
+            bbr = assertBlockAvailable("testnet3version4.blk", true, TESTNET3_MAGIC);
             ByteBuffer version4ByteBuffer = bbr.readRawBlock();
             assertTrue(version4ByteBuffer.isDirect(), "Random TestNet3 Version 4 Raw Block is DirectByteBuffer");
             assertEquals(749041, version4ByteBuffer.limit(), "Random TestNet3  Version 4 Raw Block has a size of 749.041 bytes");
@@ -322,7 +310,7 @@ public class BitcoinFormatReaderTest {
     public void parseMultiNetAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("multinet.blk", true, MULTINET_MAGIC);
+            bbr = assertBlockAvailable("multinet.blk", true, MULTINET_MAGIC);
             ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
             assertTrue(firstMultinetByteBuffer.isDirect(), "First MultiNetBlock is DirectByteBuffer");
             assertEquals(293, firstMultinetByteBuffer.limit(), "First MultiNetBlock has a size of 293 bytes");
@@ -342,7 +330,7 @@ public class BitcoinFormatReaderTest {
     public void parseScriptWitnessBlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("scriptwitness.blk", true);
+            bbr = assertBlockAvailable("scriptwitness.blk", true);
             ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
             assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
             assertEquals(999283, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999283 bytes");
@@ -356,7 +344,7 @@ public class BitcoinFormatReaderTest {
     public void parseScriptWitness2BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("scriptwitness2.blk", true);
+            bbr = assertBlockAvailable("scriptwitness2.blk", true);
             ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
             assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
             assertEquals(1000039, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 1000039 bytes");
@@ -373,7 +361,7 @@ public class BitcoinFormatReaderTest {
     public void parseGenesisBlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("genesis.blk", false);
+            bbr = assertBlockAvailable("genesis.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1, theBitcoinBlock.getTransactions().size(), "Genesis Block must contain exactly one transaction");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Genesis Block must contain exactly one transaction with one input");
@@ -391,7 +379,7 @@ public class BitcoinFormatReaderTest {
     public void parseTestNet3GenesisBlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("testnet3genesis.blk", false, TESTNET3_MAGIC);
+            bbr = assertBlockAvailable("testnet3genesis.blk", false, TESTNET3_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1, theBitcoinBlock.getTransactions().size(), "TestNet3 Genesis Block must contain exactly one transaction");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one input");
@@ -408,7 +396,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion1BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version1.blk", false);
+            bbr = assertBlockAvailable("version1.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(2, theBitcoinBlock.getTransactions().size(), "Random Version 1 Block must contain exactly two transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one input");
@@ -425,7 +413,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion2BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version2.blk", false, DEFAULT_MAGIC);
+            bbr = assertBlockAvailable("version2.blk", false, DEFAULT_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(343, theBitcoinBlock.getTransactions().size(), "Random Version 2 Block must contain exactly 343 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
@@ -442,7 +430,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion3BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version3.blk", false);
+            bbr = assertBlockAvailable("version3.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1645, theBitcoinBlock.getTransactions().size(), "Random Version 3 Block must contain exactly 1645 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
@@ -459,7 +447,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion4BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version4.blk", false);
+            bbr = assertBlockAvailable("version4.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(936, theBitcoinBlock.getTransactions().size(), "Random Version 4 Block must contain exactly 936 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
@@ -476,7 +464,7 @@ public class BitcoinFormatReaderTest {
     public void parseTestNet3Version4BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("testnet3version4.blk", false, TESTNET3_MAGIC);
+            bbr = assertBlockAvailable("testnet3version4.blk", false, TESTNET3_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(3299, theBitcoinBlock.getTransactions().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
@@ -493,7 +481,7 @@ public class BitcoinFormatReaderTest {
     public void parseMultiNetBlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("multinet.blk", false, MULTINET_MAGIC);
+            bbr = assertBlockAvailable("multinet.blk", false, MULTINET_MAGIC);
             BitcoinBlock firstBitcoinBlock = bbr.readBlock();
             assertEquals(1, firstBitcoinBlock.getTransactions().size(), "First MultiNet Block must contain exactly one transaction");
             assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "First MultiNet Block must contain exactly one transaction with one input");
@@ -522,7 +510,7 @@ public class BitcoinFormatReaderTest {
     public void parseScriptWitnessBlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("scriptwitness.blk", false);
+            bbr = assertBlockAvailable("scriptwitness.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(470, theBitcoinBlock.getTransactions().size(), "Random ScriptWitness Block must contain exactly 470 transactions");
         } finally {
@@ -535,7 +523,7 @@ public class BitcoinFormatReaderTest {
     public void parseScriptWitness2BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("scriptwitness2.blk", false);
+            bbr = assertBlockAvailable("scriptwitness2.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(2191, theBitcoinBlock.getTransactions().size(), "First random ScriptWitness Block must contain exactly 2191 transactions");
             theBitcoinBlock = bbr.readBlock();
@@ -550,7 +538,7 @@ public class BitcoinFormatReaderTest {
     public void parseGenesisBlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("genesis.blk", true);
+            bbr = assertBlockAvailable("genesis.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1, theBitcoinBlock.getTransactions().size(), "Genesis Block must contain exactly one transaction");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Genesis Block must contain exactly one transaction with one input");
@@ -567,7 +555,7 @@ public class BitcoinFormatReaderTest {
     public void parseTestNet3GenesisBlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("testnet3genesis.blk", true, TESTNET3_MAGIC);
+            bbr = assertBlockAvailable("testnet3genesis.blk", true, TESTNET3_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1, theBitcoinBlock.getTransactions().size(), "TestNet3 Genesis Block must contain exactly one transaction");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one input");
@@ -585,7 +573,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion1BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version1.blk", true);
+            bbr = assertBlockAvailable("version1.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(2, theBitcoinBlock.getTransactions().size(), "Random Version 1 Block must contain exactly two transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one input");
@@ -602,7 +590,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion2BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version2.blk", true);
+            bbr = assertBlockAvailable("version2.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(343, theBitcoinBlock.getTransactions().size(), "Random Version 2 Block must contain exactly 343 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
@@ -619,7 +607,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion3BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version3.blk", true);
+            bbr = assertBlockAvailable("version3.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1645, theBitcoinBlock.getTransactions().size(), "Random Version 3 Block must contain exactly 1645 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
@@ -636,7 +624,7 @@ public class BitcoinFormatReaderTest {
     public void parseVersion4BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("version4.blk", true);
+            bbr = assertBlockAvailable("version4.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(936, theBitcoinBlock.getTransactions().size(), "Random Version 4 Block must contain exactly 936 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
@@ -653,7 +641,7 @@ public class BitcoinFormatReaderTest {
     public void parseTestNet3Version4BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("testnet3version4.blk", true, TESTNET3_MAGIC);
+            bbr = assertBlockAvailable("testnet3version4.blk", true, TESTNET3_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(3299, theBitcoinBlock.getTransactions().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
@@ -670,7 +658,7 @@ public class BitcoinFormatReaderTest {
     public void parseMultiNetBlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("multinet.blk", true, MULTINET_MAGIC);
+            bbr = assertBlockAvailable("multinet.blk", true, MULTINET_MAGIC);
             BitcoinBlock firstBitcoinBlock = bbr.readBlock();
             assertEquals(1, firstBitcoinBlock.getTransactions().size(), "First MultiNet Block must contain exactly one transaction");
             assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "First MultiNet Block must contain exactly one transaction with one input");
@@ -699,7 +687,7 @@ public class BitcoinFormatReaderTest {
     public void parseScriptWitnessBlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("scriptwitness.blk", true);
+            bbr = assertBlockAvailable("scriptwitness.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(470, theBitcoinBlock.getTransactions().size(), "Random ScriptWitness Block must contain exactly 470 transactions");
         } finally {
@@ -712,7 +700,7 @@ public class BitcoinFormatReaderTest {
     public void parseScriptWitness2BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("scriptwitness2.blk", true);
+            bbr = assertBlockAvailable("scriptwitness2.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(2191, theBitcoinBlock.getTransactions().size(), "First random ScriptWitness Block must contain exactly 2191 transactions");
             theBitcoinBlock = bbr.readBlock();
@@ -727,7 +715,7 @@ public class BitcoinFormatReaderTest {
     public void seekBlockStartHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("reqseekversion1.blk", false);
+            bbr = assertBlockAvailable("reqseekversion1.blk", false);
             bbr.seekBlockStart();
             ByteBuffer version1ByteBuffer = bbr.readRawBlock();
             assertFalse(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block (requiring seek) is HeapByteBuffer");
@@ -742,7 +730,7 @@ public class BitcoinFormatReaderTest {
     public void seekBlockStartDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("reqseekversion1.blk", true);
+            bbr = assertBlockAvailable("reqseekversion1.blk", true);
             bbr.seekBlockStart();
             ByteBuffer version1ByteBuffer = bbr.readRawBlock();
             assertTrue(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block (requiring seek) is DirectByteBuffer");
@@ -757,7 +745,7 @@ public class BitcoinFormatReaderTest {
     public void getKeyFromRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("genesis.blk", false);
+            bbr = assertBlockAvailable("genesis.blk", false);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertFalse(genesisByteBuffer.isDirect(), "Raw Genesis Block is HeapByteBuffer");
             byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
@@ -774,7 +762,7 @@ public class BitcoinFormatReaderTest {
     public void getKeyFromRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
         try {
-            bbr = blockReader("genesis.blk", true);
+            bbr = assertBlockAvailable("genesis.blk", true);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertTrue(genesisByteBuffer.isDirect(), "Raw Genesis Block is DirectByteBuffer");
             byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
@@ -791,18 +779,19 @@ public class BitcoinFormatReaderTest {
         return Objects.requireNonNull(getClass().getClassLoader().getResource("testdata/" + fileName)).getFile();
     }
 
-    public BitcoinBlockReader blockReader(String fileName, boolean direct) throws IOException {
-        return blockReader(fileName, direct, DEFAULT_MAGIC);
+    public BitcoinBlockReader assertBlockAvailable(String fileName, boolean direct) throws IOException {
+        return assertBlockAvailable(fileName, direct, DEFAULT_MAGIC);
     }
 
-    public BitcoinBlockReader blockReader(String fileName, boolean direct, byte[][] magic) throws IOException {
+    public BitcoinBlockReader assertBlockAvailable(String fileName, boolean direct, byte[][] magic) throws IOException {
+        assertTestFileAvailable(fileName);
         File file = new File(getFullFilename(fileName));
         FileInputStream fin = new FileInputStream(file);
         return new BitcoinBlockReader(fin, DEFAULT_MAXSIZE_BITCOINBLOCK, DEFAULT_BUFFERSIZE, magic, direct);
     }
 
     public BitcoinBlockReader genesisBlockReader(boolean direct) throws IOException {
-        return blockReader("genesis.blk", direct);
+        return assertBlockAvailable("genesis.blk", direct);
     }
 
     public void assertTestFileAvailable(String fileName) {

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
@@ -16,27 +16,26 @@
 
 package org.zuinnote.hadoop.bitcoin.format.common;
 
-
 import org.junit.jupiter.api.Test;
 import org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 
 public class BitcoinFormatReaderTest {
+
     static final int DEFAULT_BUFFERSIZE = 64 * 1024;
     static final int DEFAULT_MAXSIZE_BITCOINBLOCK = 8 * 1024 * 1024;
     static final byte[][] DEFAULT_MAGIC = {{(byte) 0xF9, (byte) 0xBE, (byte) 0xB4, (byte) 0xD9}};
@@ -44,146 +43,24 @@ public class BitcoinFormatReaderTest {
     private static final byte[][] MULTINET_MAGIC = {{(byte) 0xF9, (byte) 0xBE, (byte) 0xB4, (byte) 0xD9}, {(byte) 0x0B, (byte) 0x11, (byte) 0x09, (byte) 0x07}};
 
     @Test
-    public void checkTestDataGenesisBlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-
-    @Test
-    public void checkTestDataVersion1BlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version1.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    public void checkTestDataAvailable() {
+        String[] testFiles = new String[] {
+                "genesis.blk", "version1.blk", "version2.blk", "version3.blk", "version4.blk",
+                "reqseekversion1.blk", "testnet3genesis.blk", "testnet3version4.blk", "testnet3version4.blk",
+                "multinet.blk", "scriptwitness.blk", "scriptwitness2.blk"};
+        for(String fileName: testFiles) {
+            testAvailable(fileName);
+        }
     }
 
     @Test
-    public void checkTestDataVersion2BlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version2.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-
-    @Test
-    public void checkTestDataVersion3BlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version3.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-    @Test
-    public void checkTestDataVersion4BlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version4.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-    @Test
-    public void checkTestDataVersion1SeekBlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "reqseekversion1.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-    @Test
-    public void checkTestDataTestnet3GenesisBlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-
-    @Test
-    public void checkTestDataTestnet3Version4BlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3version4.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-
-    @Test
-    public void checkTestDataMultiNetAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "multinet.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-    @Test
-    public void checkTestDataScriptWitnessNetAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-    @Test
-    public void checkTestDataScriptWitness2NetAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness2.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-
-    @Test
-    public void parseGenesisBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void parseGenesisBlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("genesis.blk", false);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertFalse(genesisByteBuffer.isDirect(), "Raw Genesis Block is HeapByteBuffer");
             assertEquals(293, genesisByteBuffer.limit(), "Raw Genesis block has a size of 293 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -191,20 +68,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion1BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version1.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion1BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version1.blk", false);
             ByteBuffer version1ByteBuffer = bbr.readRawBlock();
             assertFalse(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block is HeapByteBuffer");
             assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block has a size of 482 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -212,42 +82,27 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion2BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version2.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion2BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version2.blk", false);
             ByteBuffer version2ByteBuffer = bbr.readRawBlock();
             assertFalse(version2ByteBuffer.isDirect(), "Random Version 2 Raw Block is HeapByteBuffer");
             assertEquals(191198, version2ByteBuffer.limit(), "Random Version 2 Raw Block has a size of 191.198 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
         }
     }
 
-
     @Test
-    public void parseVersion3BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version3.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion3BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version3.blk", false);
             ByteBuffer version3ByteBuffer = bbr.readRawBlock();
             assertFalse(version3ByteBuffer.isDirect(), "Random Version 3 Raw Block is HeapByteBuffer");
             assertEquals(932199, version3ByteBuffer.limit(), "Random Version 3 Raw Block has a size of 932.199 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -255,20 +110,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion4BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version4.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion4BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version4.blk", false);
             ByteBuffer version4ByteBuffer = bbr.readRawBlock();
             assertFalse(version4ByteBuffer.isDirect(), "Random Version 4 Raw Block is HeapByteBuffer");
             assertEquals(998039, version4ByteBuffer.limit(), "Random Version 4 Raw Block has a size of 998.039 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -276,20 +124,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseTestNet3GenesisBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void parseTestNet3GenesisBlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3genesis.blk", false, TESTNET3_MAGIC);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertFalse(genesisByteBuffer.isDirect(), "Raw TestNet3 Genesis Block is HeapByteBuffer");
             assertEquals(293, genesisByteBuffer.limit(), "Raw TestNet3 Genesis block has a size of 293 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -297,38 +138,24 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseTestNet3Version4BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3version4.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseTestNet3Version4BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3version4.blk", false, TESTNET3_MAGIC);
             ByteBuffer version4ByteBuffer = bbr.readRawBlock();
             assertFalse(version4ByteBuffer.isDirect(), "Random TestNet3 Version 4 Raw Block is HeapByteBuffer");
             assertEquals(749041, version4ByteBuffer.limit(), "Random TestNet3 Version 4 Raw Block has a size of 749.041 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
         }
     }
 
-
     @Test
-    public void parseMultiNetAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "multinet.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void parseMultiNetAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            bbr = blockReader("multinet.blk", false, MULTINET_MAGIC);
             ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
             assertFalse(firstMultinetByteBuffer.isDirect(), "First MultiNetBlock is HeapByteBuffer");
             assertEquals(293, firstMultinetByteBuffer.limit(), "First MultiNetBlock has a size of 293 bytes");
@@ -338,8 +165,6 @@ public class BitcoinFormatReaderTest {
             ByteBuffer thirdMultinetByteBuffer = bbr.readRawBlock();
             assertFalse(thirdMultinetByteBuffer.isDirect(), "Third MultiNetBlock is HeapByteBuffer");
             assertEquals(749041, thirdMultinetByteBuffer.limit(), "Third MultiNetBlock has a size of 749.041 bytes");
-
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -347,26 +172,18 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseScriptWitnessBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseScriptWitnessBlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness.blk", false);
             ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
             assertFalse(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is HeapByteBuffer");
             assertEquals(999283, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999283 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
         }
     }
-
 
     @Test
     public void parseScriptWitness2BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
@@ -383,20 +200,6 @@ public class BitcoinFormatReaderTest {
             if (bbr != null)
                 bbr.close();
         }
-    }
-
-    public BitcoinBlockReader blockReader(String fileName, boolean direct) throws IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
-        BitcoinBlockReader bbr = null;
-        FileInputStream fin = new FileInputStream(file);
-        return new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE,
-                                                this.DEFAULT_MAGIC, direct);
-    }
-
-    public BitcoinBlockReader genesisBlockReader(boolean direct) throws IOException, BitcoinBlockReadException {
-        return blockReader("genesis.blk", direct);
     }
 
     @Test
@@ -422,7 +225,7 @@ public class BitcoinFormatReaderTest {
         Calendar x = new GregorianCalendar();
         x.setTime(expected);
         Calendar y = new GregorianCalendar();
-        y.setTime(expected);
+        y.setTime(actual);
         Integer[] fields = new Integer[]
             {Calendar.YEAR, Calendar.MONTH, Calendar.DAY_OF_MONTH, Calendar.HOUR_OF_DAY, Calendar.MINUTE};
         for(int field : fields) {
@@ -448,20 +251,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion1BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version1.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion1BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version1.blk", true);
             ByteBuffer version1ByteBuffer = bbr.readRawBlock();
             assertTrue(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block is DirectByteBuffer");
             assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block has a size of 482 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -469,20 +265,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion2BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version2.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion2BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version2.blk", true);
             ByteBuffer version2ByteBuffer = bbr.readRawBlock();
             assertTrue(version2ByteBuffer.isDirect(), "Random Version 2 Raw Block is DirectByteBuffer");
             assertEquals(191198, version2ByteBuffer.limit(), "Random Version 2 Raw Block has a size of 191.198 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -490,20 +279,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion3BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version3.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion3BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version3.blk", true);
             ByteBuffer version3ByteBuffer = bbr.readRawBlock();
             assertTrue(version3ByteBuffer.isDirect(), "Random Version 3 Raw Block is DirectByteBuffer");
             assertEquals(932199, version3ByteBuffer.limit(), "Random Version 3 Raw Block has a size of 932.199 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -511,20 +293,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion4BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version4.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion4BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version4.blk", true);
             ByteBuffer version4ByteBuffer = bbr.readRawBlock();
             assertTrue(version4ByteBuffer.isDirect(), "Random Version 4 Raw Block is DirectByteBuffer");
             assertEquals(998039, version4ByteBuffer.limit(), "Random Version 4 Raw Block has a size of 998.039 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -532,20 +307,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseTestNet3GenesisBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void parseTestNet3GenesisBlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3genesis.blk", true, TESTNET3_MAGIC);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertTrue(genesisByteBuffer.isDirect(), "Raw TestNet3 Genesis Block is DirectByteBuffer");
             assertEquals(293, genesisByteBuffer.limit(), "Raw TestNet3 Genesis block has a size of 293 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -553,20 +321,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseTestNet3Version4BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3version4.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseTestNet3Version4BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3version4.blk", true, TESTNET3_MAGIC);
             ByteBuffer version4ByteBuffer = bbr.readRawBlock();
             assertTrue(version4ByteBuffer.isDirect(), "Random TestNet3 Version 4 Raw Block is DirectByteBuffer");
             assertEquals(749041, version4ByteBuffer.limit(), "Random TestNet3  Version 4 Raw Block has a size of 749.041 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -574,16 +335,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseMultiNetAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "multinet.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void parseMultiNetAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            bbr = blockReader("multinet.blk", true, MULTINET_MAGIC);
             ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
             assertTrue(firstMultinetByteBuffer.isDirect(), "First MultiNetBlock is DirectByteBuffer");
             assertEquals(293, firstMultinetByteBuffer.limit(), "First MultiNetBlock has a size of 293 bytes");
@@ -593,8 +348,6 @@ public class BitcoinFormatReaderTest {
             ByteBuffer thirdMultinetByteBuffer = bbr.readRawBlock();
             assertTrue(thirdMultinetByteBuffer.isDirect(), "Third MultiNetBlock is DirectByteBuffer");
             assertEquals(749041, thirdMultinetByteBuffer.limit(), "Third MultiNetBlock has a size of 749.041 bytes");
-
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -602,20 +355,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseScriptWitnessBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseScriptWitnessBlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness.blk", true);
             ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
             assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
             assertEquals(999283, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999283 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -623,41 +369,27 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseScriptWitness2BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness2.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseScriptWitness2BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness2.blk", true);
             ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
             assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
             assertEquals(1000039, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 1000039 bytes");
             scriptwitnessByteBuffer = bbr.readRawBlock();
             assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
             assertEquals(999312, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999312 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
         }
     }
 
-
     @Test
-    public void parseGenesisBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "genesis.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseGenesisBlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("genesis.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1, theBitcoinBlock.getTransactions().size(), "Genesis Block must contain exactly one transaction");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Genesis Block must contain exactly one transaction with one input");
@@ -671,18 +403,11 @@ public class BitcoinFormatReaderTest {
         }
     }
 
-
     @Test
-    public void parseTestNet3GenesisBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3genesis.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseTestNet3GenesisBlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3genesis.blk", false, TESTNET3_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1, theBitcoinBlock.getTransactions().size(), "TestNet3 Genesis Block must contain exactly one transaction");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one input");
@@ -696,16 +421,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion1BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version1.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion1BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version1.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(2, theBitcoinBlock.getTransactions().size(), "Random Version 1 Block must contain exactly two transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one input");
@@ -719,16 +438,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion2BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version2.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion2BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version2.blk", false, DEFAULT_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(343, theBitcoinBlock.getTransactions().size(), "Random Version 2 Block must contain exactly 343 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
@@ -742,16 +455,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion3BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version3.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion3BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version3.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1645, theBitcoinBlock.getTransactions().size(), "Random Version 3 Block must contain exactly 1645 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
@@ -765,16 +472,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion4BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version4.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion4BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version4.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(936, theBitcoinBlock.getTransactions().size(), "Random Version 4 Block must contain exactly 936 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
@@ -788,16 +489,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseTestNet3Version4BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3version4.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseTestNet3Version4BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3version4.blk", false, TESTNET3_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(3299, theBitcoinBlock.getTransactions().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
@@ -811,16 +506,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseMultiNetBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "multinet.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseMultiNetBlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            bbr = blockReader("multinet.blk", false, MULTINET_MAGIC);
             BitcoinBlock firstBitcoinBlock = bbr.readBlock();
             assertEquals(1, firstBitcoinBlock.getTransactions().size(), "First MultiNet Block must contain exactly one transaction");
             assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "First MultiNet Block must contain exactly one transaction with one input");
@@ -846,42 +535,27 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseScriptWitnessBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseScriptWitnessBlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(470, theBitcoinBlock.getTransactions().size(), "Random ScriptWitness Block must contain exactly 470 transactions");
-
         } finally {
             if (bbr != null)
                 bbr.close();
         }
     }
 
-
     @Test
-    public void parseScriptWitness2BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness2.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseScriptWitness2BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness2.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(2191, theBitcoinBlock.getTransactions().size(), "First random ScriptWitness Block must contain exactly 2191 transactions");
             theBitcoinBlock = bbr.readBlock();
             assertEquals(2508, theBitcoinBlock.getTransactions().size(), "Second random ScriptWitness Block must contain exactly 2508 transactions");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -889,16 +563,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseGenesisBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "genesis.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseGenesisBlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("genesis.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1, theBitcoinBlock.getTransactions().size(), "Genesis Block must contain exactly one transaction");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Genesis Block must contain exactly one transaction with one input");
@@ -911,18 +579,11 @@ public class BitcoinFormatReaderTest {
         }
     }
 
-
     @Test
-    public void parseTestNet3GenesisBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3genesis.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseTestNet3GenesisBlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3genesis.blk", true, TESTNET3_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1, theBitcoinBlock.getTransactions().size(), "TestNet3 Genesis Block must contain exactly one transaction");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one input");
@@ -937,16 +598,10 @@ public class BitcoinFormatReaderTest {
 
 
     @Test
-    public void parseVersion1BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version1.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion1BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version1.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(2, theBitcoinBlock.getTransactions().size(), "Random Version 1 Block must contain exactly two transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one input");
@@ -960,16 +615,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion2BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version2.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion2BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version2.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(343, theBitcoinBlock.getTransactions().size(), "Random Version 2 Block must contain exactly 343 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
@@ -983,16 +632,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion3BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version3.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion3BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version3.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1645, theBitcoinBlock.getTransactions().size(), "Random Version 3 Block must contain exactly 1645 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
@@ -1006,16 +649,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion4BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version4.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion4BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version4.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(936, theBitcoinBlock.getTransactions().size(), "Random Version 4 Block must contain exactly 936 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
@@ -1028,18 +665,11 @@ public class BitcoinFormatReaderTest {
         }
     }
 
-
     @Test
-    public void parseTestNet3Version4BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3version4.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseTestNet3Version4BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3version4.blk", true, TESTNET3_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(3299, theBitcoinBlock.getTransactions().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
@@ -1053,16 +683,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseMultiNetBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "multinet.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseMultiNetBlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            bbr = blockReader("multinet.blk", true, MULTINET_MAGIC);
             BitcoinBlock firstBitcoinBlock = bbr.readBlock();
             assertEquals(1, firstBitcoinBlock.getTransactions().size(), "First MultiNet Block must contain exactly one transaction");
             assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "First MultiNet Block must contain exactly one transaction with one input");
@@ -1087,21 +711,13 @@ public class BitcoinFormatReaderTest {
         }
     }
 
-
     @Test
-    public void parseScriptWitnessBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseScriptWitnessBlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(470, theBitcoinBlock.getTransactions().size(), "Random ScriptWitness Block must contain exactly 470 transactions");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -1109,21 +725,14 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseScriptWitness2BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness2.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseScriptWitness2BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness2.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(2191, theBitcoinBlock.getTransactions().size(), "First random ScriptWitness Block must contain exactly 2191 transactions");
             theBitcoinBlock = bbr.readBlock();
             assertEquals(2508, theBitcoinBlock.getTransactions().size(), "Second random ScriptWitness Block must contain exactly 2508 transactions");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -1131,21 +740,14 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void seekBlockStartHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "reqseekversion1.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void seekBlockStartHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("reqseekversion1.blk", false);
             bbr.seekBlockStart();
             ByteBuffer version1ByteBuffer = bbr.readRawBlock();
             assertFalse(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block (requiring seek) is HeapByteBuffer");
             assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block (requiring seek) has a size of 482 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -1153,21 +755,14 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void seekBlockStartDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "reqseekversion1.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void seekBlockStartDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("reqseekversion1.blk", true);
             bbr.seekBlockStart();
             ByteBuffer version1ByteBuffer = bbr.readRawBlock();
             assertTrue(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block (requiring seek) is DirectByteBuffer");
             assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block (requiring seek) has a size of 482 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -1175,23 +770,16 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void getKeyFromRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void getKeyFromRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("genesis.blk", false);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertFalse(genesisByteBuffer.isDirect(), "Raw Genesis Block is HeapByteBuffer");
             byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
             assertEquals(64, key.length, "Raw Genesis Block Key should have a size of 64 bytes");
             byte[] comparatorKey = new byte[]{(byte) 0x3B, (byte) 0xA3, (byte) 0xED, (byte) 0xFD, (byte) 0x7A, (byte) 0x7B, (byte) 0x12, (byte) 0xB2, (byte) 0x7A, (byte) 0xC7, (byte) 0x2C, (byte) 0x3E, (byte) 0x67, (byte) 0x76, (byte) 0x8F, (byte) 0x61, (byte) 0x7F, (byte) 0xC8, (byte) 0x1B, (byte) 0xC3, (byte) 0x88, (byte) 0x8A, (byte) 0x51, (byte) 0x32, (byte) 0x3A, (byte) 0x9F, (byte) 0xB8, (byte) 0xAA, (byte) 0x4B, (byte) 0x1E, (byte) 0x5E, (byte) 0x4A, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00};
             assertArrayEquals(comparatorKey, key, "Raw Genesis Block Key is equivalent to comparator key");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -1199,30 +787,45 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void getKeyFromRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void getKeyFromRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("genesis.blk", true);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertTrue(genesisByteBuffer.isDirect(), "Raw Genesis Block is DirectByteBuffer");
             byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
             assertEquals(64, key.length, "Raw Genesis Block Key should have a size of 64 bytes");
             byte[] comparatorKey = new byte[]{(byte) 0x3B, (byte) 0xA3, (byte) 0xED, (byte) 0xFD, (byte) 0x7A, (byte) 0x7B, (byte) 0x12, (byte) 0xB2, (byte) 0x7A, (byte) 0xC7, (byte) 0x2C, (byte) 0x3E, (byte) 0x67, (byte) 0x76, (byte) 0x8F, (byte) 0x61, (byte) 0x7F, (byte) 0xC8, (byte) 0x1B, (byte) 0xC3, (byte) 0x88, (byte) 0x8A, (byte) 0x51, (byte) 0x32, (byte) 0x3A, (byte) 0x9F, (byte) 0xB8, (byte) 0xAA, (byte) 0x4B, (byte) 0x1E, (byte) 0x5E, (byte) 0x4A, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00};
             assertArrayEquals(comparatorKey, key, "Raw Genesis Block Key is equivalent to comparator key");
-
         } finally {
             if (bbr != null)
                 bbr.close();
         }
     }
 
+    public String getFullFilename(String fileName) {
+        return Objects.requireNonNull(getClass().getClassLoader().getResource("testdata/" + fileName)).getFile();
+    }
+
+    public void testAvailable(String fileName) {
+        String fullFilename = getFullFilename(fileName);
+        File file = new File(fullFilename);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    public BitcoinBlockReader blockReader(String fileName, boolean direct) throws IOException {
+        return blockReader(fileName, direct, DEFAULT_MAGIC);
+    }
+
+    public BitcoinBlockReader blockReader(String fileName, boolean direct, byte[][] magic) throws IOException {
+        File file = new File(getFullFilename(fileName));
+        FileInputStream fin = new FileInputStream(file);
+        return new BitcoinBlockReader(fin, DEFAULT_MAXSIZE_BITCOINBLOCK, DEFAULT_BUFFERSIZE, magic, direct);
+    }
+
+    public BitcoinBlockReader genesisBlockReader(boolean direct) throws IOException {
+        return blockReader("genesis.blk", direct);
+    }
 
 }
-
-


### PR DESCRIPTION
- refactored unit tests to remove duplicated code by introducing helper methods and custom assert methods as per the advice in [this stackoverflow post](https://stackoverflow.com/questions/129693/is-duplicated-code-more-tolerable-in-unit-tests) as per issue #72.

- introduced a new unit-test to check that time field from genesis block is correct.

- reformatted code to adhere to style guide.

- fixed dangling javadoc comment in copyright message.
