### PR TITLE
Unsigned 32-bit integers stored correctly in BitcoinBlock

### DIFF
--- a/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinBlock.java
+++ b/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinBlock.java
@@ -1,18 +1,18 @@
 /**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+ * Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
 
 package org.zuinnote.hadoop.bitcoin.format.common;
 
@@ -27,153 +27,151 @@ import java.util.List;
 import java.util.ArrayList;
 
 /**
-* This class is an object storing relevant fields of a Bitcoin Block. 
-*/
+ * This class is an object storing relevant fields of a Bitcoin Block.
+ */
 
 public class BitcoinBlock implements Serializable, Writable {
 
 
-private int blockSize;
-private byte[] magicNo;
-private int version;
-private int time;
-private byte[] bits;
-private int nonce;
-private long transactionCounter;
-private byte[] hashPrevBlock;
-private byte[] hashMerkleRoot;
-private List<BitcoinTransaction> transactions;
-private BitcoinAuxPOW auxPOW;
+    private int blockSize;
+    private byte[] magicNo;
+    private int version;
+    private int time;
+    private byte[] bits;
+    private int nonce;
+    private long transactionCounter;
+    private byte[] hashPrevBlock;
+    private byte[] hashMerkleRoot;
+    private List<BitcoinTransaction> transactions;
+    private BitcoinAuxPOW auxPOW;
 
-public BitcoinBlock() {
-	this.magicNo=new byte[0];
-	this.bits=new byte[0];
-	this.transactionCounter=0;
-	this.hashPrevBlock=new byte[0];
-	this.hashMerkleRoot=new byte[0];
-	this.transactions=new ArrayList<>();
-	this.auxPOW=new BitcoinAuxPOW();
-}
-
-
-public int getBlockSize() {
-	return this.blockSize;
-}
-
-public void setBlockSize(int blockSize) {
-	this.blockSize=blockSize;
-}
+    public BitcoinBlock() {
+        this.magicNo = new byte[0];
+        this.bits = new byte[0];
+        this.transactionCounter = 0;
+        this.hashPrevBlock = new byte[0];
+        this.hashMerkleRoot = new byte[0];
+        this.transactions = new ArrayList<>();
+        this.auxPOW = new BitcoinAuxPOW();
+    }
 
 
-public byte[] getMagicNo() {
-	return this.magicNo;
-}
+    public int getBlockSize() {
+        return this.blockSize;
+    }
 
-public void setMagicNo(byte[] magicNo) {
-	this.magicNo=magicNo;
-}
-
-public int getVersion() {
-	return this.version;
-}
-
-public void setVersion(int version) {
-	this.version=version;
-}
-
-public int getTime() {
-	return this.time;
-}
-
-public void setTime(int time) {
-	this.time=time;
-}
-
-public byte[] getBits() {
-	return this.bits;
-}
-
-public void setBits(byte[] bits) {
-	this.bits=bits;
-}
-
-public int getNonce() {
-	return this.nonce;
-}
-
-public void setNonce(int nonce) {
-	this.nonce=nonce;
-}
-
-public long getTransactionCounter() {
-	return this.transactionCounter;
-}
+    public void setBlockSize(int blockSize) {
+        this.blockSize = blockSize;
+    }
 
 
-public void setTransactionCounter(long transactionCounter) {
-	this.transactionCounter=transactionCounter;
-}
+    public byte[] getMagicNo() {
+        return this.magicNo;
+    }
 
-public byte[] getHashPrevBlock() {
-	return this.hashPrevBlock;
-}
+    public void setMagicNo(byte[] magicNo) {
+        this.magicNo = magicNo;
+    }
 
-public void setHashPrevBlock(byte[] hashPrevBlock) {
-	this.hashPrevBlock=hashPrevBlock;
-}
+    public int getVersion() {
+        return this.version;
+    }
 
-public byte[] getHashMerkleRoot() {
-	return this.hashMerkleRoot;
-}
+    public void setVersion(int version) {
+        this.version = version;
+    }
 
-public void setHashMerkleRoot(byte[] hashMerkleRoot) {
-	this.hashMerkleRoot=hashMerkleRoot;
-}
+    public int getTime() {
+        return this.time;
+    }
 
-public List<BitcoinTransaction> getTransactions() {
-	return this.transactions;
-}
+    public void setTime(int time) {
+        this.time = time;
+    }
 
-public void setTransactions(List<BitcoinTransaction> transactions) {
-	this.transactions=transactions;
-}
+    public byte[] getBits() {
+        return this.bits;
+    }
 
-public BitcoinAuxPOW getAuxPOW() {
-	return this.auxPOW;
-}
+    public void setBits(byte[] bits) {
+        this.bits = bits;
+    }
 
+    public int getNonce() {
+        return this.nonce;
+    }
 
-public void setAuxPOW(BitcoinAuxPOW auxPOW) {
-	this.auxPOW = auxPOW;
-}
+    public void setNonce(int nonce) {
+        this.nonce = nonce;
+    }
 
-public void set(BitcoinBlock newBitcoinBlock) {
-	this.blockSize=newBitcoinBlock.getBlockSize();
-	this.magicNo=newBitcoinBlock.getMagicNo();
-	this.version=newBitcoinBlock.getVersion();
-	this.time=newBitcoinBlock.getTime();
-	this.bits=newBitcoinBlock.getBits();
-	this.nonce=newBitcoinBlock.getNonce();
-	this.transactionCounter=newBitcoinBlock.getTransactionCounter();
-	this.hashPrevBlock=newBitcoinBlock.getHashPrevBlock();
-	this.hashMerkleRoot=newBitcoinBlock.getHashMerkleRoot();
-	this.transactions=newBitcoinBlock.getTransactions();
-	this.auxPOW=newBitcoinBlock.getAuxPOW();
-}
-
-/** Writable **/
-
-  @Override
-  public void write(DataOutput dataOutput) throws IOException {
-    throw new UnsupportedOperationException("write unsupported");
-  }
-
-  @Override
-  public void readFields(DataInput dataInput) throws IOException {
-    throw new UnsupportedOperationException("readFields unsupported");
-  }
+    public long getTransactionCounter() {
+        return this.transactionCounter;
+    }
 
 
+    public void setTransactionCounter(long transactionCounter) {
+        this.transactionCounter = transactionCounter;
+    }
+
+    public byte[] getHashPrevBlock() {
+        return this.hashPrevBlock;
+    }
+
+    public void setHashPrevBlock(byte[] hashPrevBlock) {
+        this.hashPrevBlock = hashPrevBlock;
+    }
+
+    public byte[] getHashMerkleRoot() {
+        return this.hashMerkleRoot;
+    }
+
+    public void setHashMerkleRoot(byte[] hashMerkleRoot) {
+        this.hashMerkleRoot = hashMerkleRoot;
+    }
+
+    public List<BitcoinTransaction> getTransactions() {
+        return this.transactions;
+    }
+
+    public void setTransactions(List<BitcoinTransaction> transactions) {
+        this.transactions = transactions;
+    }
+
+    public BitcoinAuxPOW getAuxPOW() {
+        return this.auxPOW;
+    }
+
+
+    public void setAuxPOW(BitcoinAuxPOW auxPOW) {
+        this.auxPOW = auxPOW;
+    }
+
+    public void set(BitcoinBlock newBitcoinBlock) {
+        this.blockSize = newBitcoinBlock.getBlockSize();
+        this.magicNo = newBitcoinBlock.getMagicNo();
+        this.version = newBitcoinBlock.getVersion();
+        this.time = newBitcoinBlock.getTime();
+        this.bits = newBitcoinBlock.getBits();
+        this.nonce = newBitcoinBlock.getNonce();
+        this.transactionCounter = newBitcoinBlock.getTransactionCounter();
+        this.hashPrevBlock = newBitcoinBlock.getHashPrevBlock();
+        this.hashMerkleRoot = newBitcoinBlock.getHashMerkleRoot();
+        this.transactions = newBitcoinBlock.getTransactions();
+        this.auxPOW = newBitcoinBlock.getAuxPOW();
+    }
+
+    /** Writable **/
+
+    @Override
+    public void write(DataOutput dataOutput) throws IOException {
+        throw new UnsupportedOperationException("write unsupported");
+    }
+
+    @Override
+    public void readFields(DataInput dataInput) throws IOException {
+        throw new UnsupportedOperationException("readFields unsupported");
+    }
 
 
 }

--- a/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinBlock.java
+++ b/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinBlock.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.io.Writable;
 
 import java.io.Serializable;
+import java.util.Date;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -32,16 +33,15 @@ import java.util.ArrayList;
 
 public class BitcoinBlock implements Serializable, Writable {
 
-
-    private int blockSize;
+    private LittleEndianUInt32 blockSize;
     private byte[] magicNo;
-    private int version;
-    private int time;
+    private LittleEndianUInt32 version;
+    private LittleEndianUInt32 time;
     private byte[] bits;
-    private int nonce;
-    private long transactionCounter;
+    private LittleEndianUInt32 nonce;
     private byte[] hashPrevBlock;
     private byte[] hashMerkleRoot;
+    private long transactionCounter;
     private List<BitcoinTransaction> transactions;
     private BitcoinAuxPOW auxPOW;
 
@@ -56,14 +56,13 @@ public class BitcoinBlock implements Serializable, Writable {
     }
 
 
-    public int getBlockSize() {
+    public LittleEndianUInt32 getBlockSize() {
         return this.blockSize;
     }
 
-    public void setBlockSize(int blockSize) {
+    public void setBlockSize(LittleEndianUInt32 blockSize) {
         this.blockSize = blockSize;
     }
-
 
     public byte[] getMagicNo() {
         return this.magicNo;
@@ -73,19 +72,19 @@ public class BitcoinBlock implements Serializable, Writable {
         this.magicNo = magicNo;
     }
 
-    public int getVersion() {
+    public LittleEndianUInt32 getVersion() {
         return this.version;
     }
 
-    public void setVersion(int version) {
+    public void setVersion(LittleEndianUInt32 version) {
         this.version = version;
     }
 
-    public int getTime() {
+    public LittleEndianUInt32 getTime() {
         return this.time;
     }
 
-    public void setTime(int time) {
+    public void setTime(LittleEndianUInt32 time) {
         this.time = time;
     }
 
@@ -97,11 +96,11 @@ public class BitcoinBlock implements Serializable, Writable {
         this.bits = bits;
     }
 
-    public int getNonce() {
+    public LittleEndianUInt32 getNonce() {
         return this.nonce;
     }
 
-    public void setNonce(int nonce) {
+    public void setNonce(LittleEndianUInt32 nonce) {
         this.nonce = nonce;
     }
 
@@ -173,5 +172,12 @@ public class BitcoinBlock implements Serializable, Writable {
         throw new UnsupportedOperationException("readFields unsupported");
     }
 
+    public long getEpochTime() {
+        return getTime().longValue();
+    }
+
+    public Date getDate() {
+        return new Date(getEpochTime() * 1000L);
+    }
 
 }

--- a/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinBlockReader.java
+++ b/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinBlockReader.java
@@ -1,18 +1,18 @@
-/**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+/*
+  Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+  <p>
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  <p>
+  http://www.apache.org/licenses/LICENSE-2.0
+  <p>
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
 
 package org.zuinnote.hadoop.bitcoin.format.common;
 
@@ -33,735 +33,721 @@ import java.util.Arrays;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.logging.Log;
+import sun.management.LazyCompositeData;
 
 /**
-* This class reads Bitcoin blocks (in raw network format) from an input stream and returns Java objects of the class BitcoinBlock. It reuses code from the LineRecordReader due to its robustness and well-tested functionality.
-*
-**/
-
+ * This class reads Bitcoin blocks (in raw network format) from an input stream and returns Java objects of
+ * the class BitcoinBlock. It reuses code from the LineRecordReader due to its robustness and well-tested functionality.
+ */
 public class BitcoinBlockReader {
 
-private static final Log LOG = LogFactory.getLog(BitcoinBlockReader.class.getName());
+    private static final Log LOG = LogFactory.getLog(BitcoinBlockReader.class.getName());
 
-private int maxSizeBitcoinBlock=0; 
-private boolean useDirectBuffer=false;
-private boolean readAuxPow=false;
-private boolean filterSpecificMagic=false;
-private byte[][] specificMagicByteArray;
-private ByteBuffer preAllocatedDirectByteBuffer;
+    private int maxSizeBitcoinBlock = 0;
+    private boolean useDirectBuffer = false;
+    private boolean readAuxPow = false;
+    private boolean filterSpecificMagic = false;
+    private byte[][] specificMagicByteArray;
+    private ByteBuffer preAllocatedDirectByteBuffer;
 
-private InputStream bin;
+    private InputStream bin;
 
+    /**
+     * Create a BitcoinBlock reader that reads from the given stream and uses the given parameters for configuration.
+     * Note that it is assumed that the validity of this configuration is checked by BitcoinBlockRecordReader.
+     *
+     * @param in Input stream to read from
+     * @param maxSizeBitcoinBlock Maximum size of a Bitcoinblock.
+     * @param bufferSize size of the memory buffer for the givenInputStream
+     * @param specificMagicByteArray filters by specific block magic numbers if not null.
+     * @param useDirectBuffer experimental feature to use a DirectByteBuffer instead of a HeapByteBuffer
+     **/
+    public BitcoinBlockReader(InputStream in, int maxSizeBitcoinBlock, int bufferSize, byte[][] specificMagicByteArray, boolean useDirectBuffer) {
+        this(in, maxSizeBitcoinBlock, bufferSize, specificMagicByteArray, useDirectBuffer, false);
+    }
 
-/**
-* Create a BitcoinBlock reader that reads from the given stream and uses the given parameters for configuration. Note it assumed that the validity of this configuration is checked by BitcoinBlockRecordReader
-* @param in Input stream to read from
-* @param maxSizeBitcoinBlock Maximum size of a Bitcoinblock.
-* @param bufferSize size of the memory buffer for the givenInputStream
-* @param specificMagicByteArray filters by specific block magic numbers if not null. 
-* @param useDirectBuffer experimental feature to use a DirectByteBuffer instead of a HeapByteBuffer
-**/
-public BitcoinBlockReader(InputStream in,  int maxSizeBitcoinBlock, int bufferSize, byte[][] specificMagicByteArray, boolean useDirectBuffer) {
-	this(in,maxSizeBitcoinBlock,bufferSize, specificMagicByteArray, useDirectBuffer, false);
-}
-/**
-* Create a BitcoinBlock reader that reads from the given stream and uses the given parameters for configuration. Note it assumed that the validity of this configuration is checked by BitcoinBlockRecordReader
-* @param in Input stream to read from
-* @param maxSizeBitcoinBlock Maximum size of a Bitcoinblock.
-* @param bufferSize size of the memory buffer for the givenInputStream
-* @param specificMagicByteArray filters by specific block magic numbers if not null. 
-* @param useDirectBuffer experimental feature to use a DirectByteBuffer instead of a HeapByteBuffer
-* @param readAuxPow true if auxPow information should be parsed, false if not
-**/
+    /**
+     * Create a BitcoinBlock reader that reads from the given stream and uses the given parameters for configuration. Note it assumed that the validity of this configuration is checked by BitcoinBlockRecordReader
+     * @param in Input stream to read from
+     * @param maxSizeBitcoinBlock Maximum size of a Bitcoinblock.
+     * @param bufferSize size of the memory buffer for the givenInputStream
+     * @param specificMagicByteArray filters by specific block magic numbers if not null.
+     * @param useDirectBuffer experimental feature to use a DirectByteBuffer instead of a HeapByteBuffer
+     * @param readAuxPow true if auxPow information should be parsed, false if not
+     **/
+    public BitcoinBlockReader(InputStream in, int maxSizeBitcoinBlock, int bufferSize, byte[][] specificMagicByteArray, boolean useDirectBuffer, boolean readAuxPow) {
+        this.maxSizeBitcoinBlock = maxSizeBitcoinBlock;
+        this.specificMagicByteArray = specificMagicByteArray;
+        this.useDirectBuffer = useDirectBuffer;
+        if (specificMagicByteArray != null) {
+            this.filterSpecificMagic = true;
+        }
+        if (bufferSize == 0) { // use original stream
+            this.bin = in;
+        } else {
+            this.bin = new BufferedInputStream(in, bufferSize);
+        }
+        if (this.useDirectBuffer) { // in case of a DirectByteBuffer we do allocation only once for the maximum size of one block, otherwise we will have a high cost for reallocation
+            preAllocatedDirectByteBuffer = ByteBuffer.allocateDirect(this.maxSizeBitcoinBlock);
+        }
+        this.readAuxPow = readAuxPow;
+    }
 
-public BitcoinBlockReader(InputStream in, int maxSizeBitcoinBlock, int bufferSize, byte[][] specificMagicByteArray, boolean useDirectBuffer, boolean readAuxPow) {
-	this.maxSizeBitcoinBlock=maxSizeBitcoinBlock;
-	this.specificMagicByteArray=specificMagicByteArray;
-	this.useDirectBuffer=useDirectBuffer;
-	if (specificMagicByteArray!=null) {
-		this.filterSpecificMagic=true;
-	}
-	if (bufferSize==0) { // use original stream
-		this.bin=in;
-	} else {
-		this.bin=new BufferedInputStream(in,bufferSize);
-	}
-	if (this.useDirectBuffer) { // in case of a DirectByteBuffer we do allocation only once for the maximum size of one block, otherwise we will have a high cost for reallocation
-		preAllocatedDirectByteBuffer=ByteBuffer.allocateDirect(this.maxSizeBitcoinBlock);
-	}
-	this.readAuxPow=readAuxPow;
-}
+    /**
+     * Seek for a valid block start according to the following algorithm:
+     * (1) find the magic of the block
+     * (2) Check that the block can be fully read and that block size is smaller than maximum block size
+     * This functionality is particularly useful for file processing in Big Data systems, such as Hadoop and Co where we work indepently on different filesplits and cannot expect that the Bitcoin block starts directly at the beginning of the stream;
+     *
+     * @throws org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException in case of format errors of the Bitcoin Blockchain data
+     *
+     **/
+    public void seekBlockStart() throws BitcoinBlockReadException {
+        if (!(this.filterSpecificMagic)) {
+            throw new BitcoinBlockReadException("Error: Cannot seek to a block start, because no magic(s) are defined.");
+        }
+        findMagic();
+        // validate it is a full block
+        checkFullBlock();
+    }
 
+    /**
+     * Read a block into a Java object of the class Bitcoin Block. This makes analysis very easy, but might be slower for some type of analytics where you are only interested in small parts of the block. In this case it is recommended to use {@link #readRawBlock}
+     *
+     * @return BitcoinBlock
+     * @throws org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException in case of errors of reading the Bitcoin Blockchain data
+     */
+    public BitcoinBlock readBlock() throws BitcoinBlockReadException {
+        ByteBuffer rawByteBuffer = readRawBlock();
+        if (rawByteBuffer == null) {
+            return null;
+        }
+        // start parsing
+        // initialize byte arrays
+        byte[] currentMagicNo = new byte[4];
+        byte[] currentBits = new byte[4];
+        byte[] currentHashMerkleRoot = new byte[32];
+        byte[] currentHashPrevBlock = new byte[32];
+        // magic no
+        rawByteBuffer.get(currentMagicNo, 0, 4);
+        // blocksize
+        LittleEndianUInt32 currentBlockSize = new LittleEndianUInt32(rawByteBuffer.getInt());
+        // version
+        LittleEndianUInt32 currentVersion = new LittleEndianUInt32(rawByteBuffer);
+        // hashPrevBlock
+        rawByteBuffer.get(currentHashPrevBlock, 0, 32);
+        // hashMerkleRoot
+        rawByteBuffer.get(currentHashMerkleRoot, 0, 32);
+        // time
+        LittleEndianUInt32 currentTime = new LittleEndianUInt32(rawByteBuffer);
+        // bits/difficulty
+        rawByteBuffer.get(currentBits, 0, 4);
+        // nonce
+        LittleEndianUInt32 currentNonce = new LittleEndianUInt32(rawByteBuffer);
 
-/**
-* Seek for a valid block start according to the following algorithm:
-* (1) find the magic of the block 
-* (2) Check that the block can be fully read and that block size is smaller than maximum block size
-* This functionality is particularly useful for file processing in Big Data systems, such as Hadoop and Co where we work indepently on different filesplits and cannot expect that the Bitcoin block starts directly at the beginning of the stream;
-* 
-* @throws org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException in case of format errors of the Bitcoin Blockchain data
-*
-**/
+        // parse AuxPOW (if available)
+        BitcoinAuxPOW auxPOW = parseAuxPow(rawByteBuffer);
+        // read var int from transaction counter
+        long currentTransactionCounter = BitcoinUtil.convertVarIntByteBufferToLong(rawByteBuffer);
 
-public void seekBlockStart() throws BitcoinBlockReadException {
-	if (!(this.filterSpecificMagic)) {
-		throw new BitcoinBlockReadException("Error: Cannot seek to a block start, because no magic(s) are defined.");
-	}
-	findMagic();
-	// validate it is a full block
-	checkFullBlock();
-}
-
-/**
-* Read a block into a Java object of the class Bitcoin Block. This makes analysis very easy, but might be slower for some type of analytics where you are only interested in small parts of the block. In this case it is recommended to use {@link #readRawBlock}
-*
-* @return BitcoinBlock
-* @throws org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException in case of errors of reading the Bitcoin Blockchain data
-*/
-
-public BitcoinBlock readBlock() throws BitcoinBlockReadException {
-  	ByteBuffer rawByteBuffer = readRawBlock();
-	if (rawByteBuffer==null) {
-		return null;
-	}
-	// start parsing
-	// initialize byte arrays
-	byte[] currentMagicNo=new byte[4];	
-	byte[] currentBits=new byte[4];
-	byte[] currentHashMerkleRoot=new byte[32];
-	byte[] currentHashPrevBlock=new byte[32];
-	// magic no
-	rawByteBuffer.get(currentMagicNo,0,4);
-	// blocksize
-	int currentBlockSize=rawByteBuffer.getInt();
-	// version
-	int currentVersion=rawByteBuffer.getInt();
-	// hashPrevBlock
-	rawByteBuffer.get(currentHashPrevBlock,0,32);
-	// hashMerkleRoot
-	rawByteBuffer.get(currentHashMerkleRoot,0,32);	
-	// time 
-	int currentTime=rawByteBuffer.getInt();
-	// bits/difficulty
-	rawByteBuffer.get(currentBits,0,4);
-	// nonce
-	int currentNonce=rawByteBuffer.getInt();
-	
-	// parse AuxPOW (if available)
-	BitcoinAuxPOW auxPOW=parseAuxPow(rawByteBuffer);
-	// read var int from transaction counter
-	long currentTransactionCounter=BitcoinUtil.convertVarIntByteBufferToLong(rawByteBuffer);
-
-	// parse transactions 
-	List<BitcoinTransaction> allBlockTransactions=parseTransactions(rawByteBuffer,currentTransactionCounter);
-	if (allBlockTransactions.size()!=currentTransactionCounter) {
-		 throw new BitcoinBlockReadException("Error: Number of Transactions ("+allBlockTransactions.size()+") does not correspond to transaction counter in block ("+currentTransactionCounter+")");
-	}
-	BitcoinBlock result=new BitcoinBlock();
-	result.setMagicNo(currentMagicNo);
-	result.setBlockSize(currentBlockSize);
-	result.setVersion(currentVersion);
-	result.setTime(currentTime);
-	result.setBits(currentBits);
-	result.setNonce(currentNonce);
-	result.setTransactionCounter(currentTransactionCounter);
-	result.setHashPrevBlock(currentHashPrevBlock);
-	result.setHashMerkleRoot(currentHashMerkleRoot);
-	result.setAuxPOW(auxPOW);
-	result.setTransactions(allBlockTransactions);
-	return result;
-}
+        // parse transactions
+        List<BitcoinTransaction> allBlockTransactions = parseTransactions(rawByteBuffer, currentTransactionCounter);
+        if (allBlockTransactions.size() != currentTransactionCounter) {
+            throw new BitcoinBlockReadException("Error: Number of Transactions (" + allBlockTransactions.size() + ") does not correspond to transaction counter in block (" + currentTransactionCounter + ")");
+        }
+        BitcoinBlock result = new BitcoinBlock();
+        result.setMagicNo(currentMagicNo);
+        result.setBlockSize(currentBlockSize);
+        result.setVersion(currentVersion);
+        result.setTime(currentTime);
+        result.setBits(currentBits);
+        result.setNonce(currentNonce);
+        result.setTransactionCounter(currentTransactionCounter);
+        result.setHashPrevBlock(currentHashPrevBlock);
+        result.setHashMerkleRoot(currentHashMerkleRoot);
+        result.setAuxPOW(auxPOW);
+        result.setTransactions(allBlockTransactions);
+        return result;
+    }
 
 
+    /**
+     * Parses AuxPOW information (cf. https://en.bitcoin.it/wiki/Merged_mining_specification)
+     *
+     * @param rawByteBuffer
+     * @return
+     */
+    public BitcoinAuxPOW parseAuxPow(ByteBuffer rawByteBuffer) {
+        if (!this.readAuxPow) {
+            return null;
+        }
+        // in case it does not contain auxpow we need to reset
+        rawByteBuffer.mark();
+        int currentVersion = rawByteBuffer.getInt();
+        byte[] currentInCounterVarInt = BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
+        byte[] currentTransactionInputPrevTransactionHash = new byte[32];
+        rawByteBuffer.get(currentTransactionInputPrevTransactionHash, 0, 32);
+        byte[] prevTxOutIdx = new byte[4];
+        rawByteBuffer.get(prevTxOutIdx, 0, 4);
+        // detect auxPow
+        rawByteBuffer.reset();
+        byte[] expectedPrevTransactionHash = new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        byte[] expectedPrevOutIdx = new byte[]{(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
 
-/**
- * Parses AuxPOW information (cf. https://en.bitcoin.it/wiki/Merged_mining_specification)
- * 
- * @param rawByteBuffer
- * @return
- */
-public BitcoinAuxPOW parseAuxPow(ByteBuffer rawByteBuffer) {
-	if (!this.readAuxPow) {
-		return null;
-	}
-	// in case it does not contain auxpow we need to reset
-	rawByteBuffer.mark();
-	int currentVersion=rawByteBuffer.getInt();
-	byte[] currentInCounterVarInt=BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
-	byte[] currentTransactionInputPrevTransactionHash=new byte[32];
-	rawByteBuffer.get(currentTransactionInputPrevTransactionHash,0,32);
-	byte[] prevTxOutIdx = new byte[4];
-	rawByteBuffer.get(prevTxOutIdx,0,4);
-	// detect auxPow
-	rawByteBuffer.reset();
-	byte[] expectedPrevTransactionHash=new byte[]{0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00};
-	byte[] expectedPrevOutIdx = new byte[] {(byte)0xFF,(byte)0xFF,(byte)0xFF,(byte)0xFF};
+        if ((!(Arrays.equals(prevTxOutIdx, expectedPrevOutIdx)) || (!(Arrays.equals(currentTransactionInputPrevTransactionHash, expectedPrevTransactionHash))))) {
+            return null;
+        }
+        // continue reading auxPow
+        // txIn (for all of them)
+        currentVersion = rawByteBuffer.getInt();
 
-	if ((!(Arrays.equals(prevTxOutIdx,expectedPrevOutIdx))||(!(Arrays.equals(currentTransactionInputPrevTransactionHash,expectedPrevTransactionHash))))) {
-		return null;
-	}
-	// continue reading auxPow
- 	// txIn (for all of them)
-	currentVersion=rawByteBuffer.getInt();
-	
-	currentInCounterVarInt=BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
-	long currentNoOfInputs=BitcoinUtil.getVarInt(currentInCounterVarInt);
-	List<BitcoinTransactionInput> currentTransactionInput = parseTransactionInputs(rawByteBuffer, currentNoOfInputs);
+        currentInCounterVarInt = BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
+        long currentNoOfInputs = BitcoinUtil.getVarInt(currentInCounterVarInt);
+        List<BitcoinTransactionInput> currentTransactionInput = parseTransactionInputs(rawByteBuffer, currentNoOfInputs);
 
-	// txOut (for all of them)
-	byte[] currentOutCounterVarInt=BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
-	long currentNoOfOutput=BitcoinUtil.getVarInt(currentOutCounterVarInt);
-	List<BitcoinTransactionOutput> currentTransactionOutput = parseTransactionOutputs(rawByteBuffer,currentNoOfOutput);
-	int lockTime = rawByteBuffer.getInt();
-	BitcoinTransaction coinbaseTransaction= new BitcoinTransaction(currentVersion,currentInCounterVarInt,currentTransactionInput, currentOutCounterVarInt, currentTransactionOutput,lockTime);
+        // txOut (for all of them)
+        byte[] currentOutCounterVarInt = BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
+        long currentNoOfOutput = BitcoinUtil.getVarInt(currentOutCounterVarInt);
+        List<BitcoinTransactionOutput> currentTransactionOutput = parseTransactionOutputs(rawByteBuffer, currentNoOfOutput);
+        int lockTime = rawByteBuffer.getInt();
+        BitcoinTransaction coinbaseTransaction = new BitcoinTransaction(currentVersion, currentInCounterVarInt, currentTransactionInput, currentOutCounterVarInt, currentTransactionOutput, lockTime);
 
-	// read branches
-	// coinbase branch
-	byte[] coinbaseParentBlockHeaderHash=new byte[32];
-	rawByteBuffer.get(coinbaseParentBlockHeaderHash,0,32);
-	
-	BitcoinAuxPOWBranch coinbaseBranch = parseAuxPOWBranch(rawByteBuffer);
-	
-	// auxchain branch
-	BitcoinAuxPOWBranch auxChainBranch = parseAuxPOWBranch(rawByteBuffer);
+        // read branches
+        // coinbase branch
+        byte[] coinbaseParentBlockHeaderHash = new byte[32];
+        rawByteBuffer.get(coinbaseParentBlockHeaderHash, 0, 32);
 
-	// parent Block header
-	
-	byte[] parentBlockBits=new byte[4];
-	byte[] parentBlockHashMerkleRoot=new byte[32];
-	byte[] parentBlockHashPrevBlock=new byte[32];
-	
-	// version
+        BitcoinAuxPOWBranch coinbaseBranch = parseAuxPOWBranch(rawByteBuffer);
 
-	int parentBlockVersion=rawByteBuffer.getInt();
-	// hashPrevBlock
-	rawByteBuffer.get(parentBlockHashPrevBlock,0,32);
-	// hashMerkleRoot
-	rawByteBuffer.get(parentBlockHashMerkleRoot,0,32);	
-	// time 
-	int parentBlockTime=rawByteBuffer.getInt();
-	// bits/difficulty
-	rawByteBuffer.get(parentBlockBits,0,4);
-	// nonce
-	int parentBlockNonce=rawByteBuffer.getInt();
-	BitcoinAuxPOWBlockHeader parentBlockheader = new BitcoinAuxPOWBlockHeader(parentBlockVersion, parentBlockHashPrevBlock, parentBlockHashMerkleRoot, parentBlockTime, parentBlockBits, parentBlockNonce);
+        // auxchain branch
+        BitcoinAuxPOWBranch auxChainBranch = parseAuxPOWBranch(rawByteBuffer);
 
-	return new BitcoinAuxPOW(currentVersion, coinbaseTransaction, coinbaseParentBlockHeaderHash, coinbaseBranch, auxChainBranch, parentBlockheader);
-}
+        // parent Block header
 
+        byte[] parentBlockBits = new byte[4];
+        byte[] parentBlockHashMerkleRoot = new byte[32];
+        byte[] parentBlockHashPrevBlock = new byte[32];
 
-/**
- * Parse an AUXPowBranch
- * 
- * @param rawByteBuffer ByteBuffer from which the AuxPOWBranch should be parsed
- * 
- * @return AuxPOWBranch
- */
-public BitcoinAuxPOWBranch parseAuxPOWBranch(ByteBuffer rawByteBuffer) {
+        // version
 
-	byte[] noOfLinksVarInt=BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
-	long currentNoOfLinks=BitcoinUtil.getVarInt(noOfLinksVarInt);
-	ArrayList<byte[]> links = new ArrayList((int)currentNoOfLinks);
-	for (int i=0;i<currentNoOfLinks;i++) {
-		byte[] currentLink = new byte[32];
-		rawByteBuffer.get(currentLink,0,32);
-		links.add(currentLink);
-	}
-	byte[] branchSideBitmask=new byte[4];
-	rawByteBuffer.get(branchSideBitmask,0,4);
-	return new BitcoinAuxPOWBranch(noOfLinksVarInt, links, branchSideBitmask);
-}	
+        int parentBlockVersion = rawByteBuffer.getInt();
+        // hashPrevBlock
+        rawByteBuffer.get(parentBlockHashPrevBlock, 0, 32);
+        // hashMerkleRoot
+        rawByteBuffer.get(parentBlockHashMerkleRoot, 0, 32);
+        // time
+        int parentBlockTime = rawByteBuffer.getInt();
+        // bits/difficulty
+        rawByteBuffer.get(parentBlockBits, 0, 4);
+        // nonce
+        int parentBlockNonce = rawByteBuffer.getInt();
+        BitcoinAuxPOWBlockHeader parentBlockheader = new BitcoinAuxPOWBlockHeader(parentBlockVersion, parentBlockHashPrevBlock, parentBlockHashMerkleRoot, parentBlockTime, parentBlockBits, parentBlockNonce);
 
-/**
-* Parses the Bitcoin transactions in a byte buffer. 
-*
-* @param rawByteBuffer ByteBuffer from which the transactions have to be parsed
-* @param noOfTransactions Number of expected transactions
-*
-* @return Array of transactions
-*
-*
-*/
+        return new BitcoinAuxPOW(currentVersion, coinbaseTransaction, coinbaseParentBlockHeaderHash, coinbaseBranch, auxChainBranch, parentBlockheader);
+    }
 
-public List<BitcoinTransaction> parseTransactions(ByteBuffer rawByteBuffer,long noOfTransactions) {
-	ArrayList<BitcoinTransaction> resultTransactions = new ArrayList<>((int)noOfTransactions);
-	// read all transactions from ByteBuffer
-	for (int k=0;k<noOfTransactions;k++) {
-		// read version
-		int currentVersion=rawByteBuffer.getInt();
-		// read inCounter
-		byte[] currentInCounterVarInt=BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
-		
-		long currentNoOfInputs=BitcoinUtil.getVarInt(currentInCounterVarInt);
-		boolean segwit=false;
-		byte marker=1;
-		byte flag=0;
-		// check segwit marker
-		if (currentNoOfInputs==0) {
-			// this seems to be segwit - lets be sure
-			// check segwit flag
-			rawByteBuffer.mark();
-			byte segwitFlag = rawByteBuffer.get();
-			if (segwitFlag!=0) {
-				// load the real number of inputs
-				segwit=true;
-				marker=0;
-				flag=segwitFlag;
-				currentInCounterVarInt=BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
-				currentNoOfInputs=BitcoinUtil.getVarInt(currentInCounterVarInt);
-			} else {
-				LOG.warn("It seems a block with 0 transaction inputs was found");
-				rawByteBuffer.reset();
-			}
-		}
-		// read inputs
-		List<BitcoinTransactionInput> currentTransactionInput = parseTransactionInputs(rawByteBuffer, currentNoOfInputs);
-				
-		// read outCounter
-		byte[] currentOutCounterVarInt=BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
-		long currentNoOfOutput=BitcoinUtil.getVarInt(currentOutCounterVarInt);
-		// read outputs
-		List<BitcoinTransactionOutput> currentTransactionOutput = parseTransactionOutputs(rawByteBuffer,currentNoOfOutput);
-				
-		List<BitcoinScriptWitnessItem> currentListOfTransactionSegwits;
-		if (segwit) {
-			// read segwit data
-			// for each transaction input there is at least some segwit data item
-			// read scriptWitness size
-			
-			
-			 currentListOfTransactionSegwits=new ArrayList<>();
-			for (int i=0;i<currentNoOfInputs;i++) {
-				// get no of witness items for input
-				byte[] currentWitnessCounterVarInt=BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
-				long currentNoOfWitnesses=BitcoinUtil.getVarInt(currentWitnessCounterVarInt);
-				List<BitcoinScriptWitness> currentTransactionSegwit = new ArrayList<>((int)currentNoOfWitnesses);
-				for (int j=0;j<(int)currentNoOfWitnesses;j++) {
-					// read size of segwit script
-					byte[] currentTransactionSegwitScriptLength=BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
-					long currentTransactionSegwitScriptSize=BitcoinUtil.getVarInt(currentTransactionSegwitScriptLength);
-					int currentTransactionSegwitScriptSizeInt= (int)currentTransactionSegwitScriptSize;
-					// read segwit script
-					byte[] currentTransactionInSegwitScript=new byte[currentTransactionSegwitScriptSizeInt];
-					rawByteBuffer.get(currentTransactionInSegwitScript,0,currentTransactionSegwitScriptSizeInt);
-					// add segwit
-					currentTransactionSegwit.add(new BitcoinScriptWitness(currentTransactionSegwitScriptLength,currentTransactionInSegwitScript));
-				}
-				currentListOfTransactionSegwits.add(new BitcoinScriptWitnessItem(currentWitnessCounterVarInt,currentTransactionSegwit));
-			}
-		} else {
-			currentListOfTransactionSegwits=new  ArrayList<>();
-		}
-		// lock_time
-		int currentTransactionLockTime = rawByteBuffer.getInt();
-		// add transaction
-		resultTransactions.add(new BitcoinTransaction(marker,flag,currentVersion,currentInCounterVarInt,currentTransactionInput,currentOutCounterVarInt,currentTransactionOutput,currentListOfTransactionSegwits,currentTransactionLockTime));
-	}
-	return resultTransactions;
-}
+    /**
+     * Parse an AUXPowBranch
+     *
+     * @param rawByteBuffer ByteBuffer from which the AuxPOWBranch should be parsed
+     *
+     * @return AuxPOWBranch
+     */
+    public BitcoinAuxPOWBranch parseAuxPOWBranch(ByteBuffer rawByteBuffer) {
+
+        byte[] noOfLinksVarInt = BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
+        long currentNoOfLinks = BitcoinUtil.getVarInt(noOfLinksVarInt);
+        ArrayList<byte[]> links = new ArrayList((int) currentNoOfLinks);
+        for (int i = 0; i < currentNoOfLinks; i++) {
+            byte[] currentLink = new byte[32];
+            rawByteBuffer.get(currentLink, 0, 32);
+            links.add(currentLink);
+        }
+        byte[] branchSideBitmask = new byte[4];
+        rawByteBuffer.get(branchSideBitmask, 0, 4);
+        return new BitcoinAuxPOWBranch(noOfLinksVarInt, links, branchSideBitmask);
+    }
+
+    /**
+     * Parses the Bitcoin transactions in a byte buffer.
+     *
+     * @param rawByteBuffer ByteBuffer from which the transactions have to be parsed
+     * @param noOfTransactions Number of expected transactions
+     *
+     * @return Array of transactions
+     *
+     *
+     */
+    public List<BitcoinTransaction> parseTransactions(ByteBuffer rawByteBuffer, long noOfTransactions) {
+        ArrayList<BitcoinTransaction> resultTransactions = new ArrayList<>((int) noOfTransactions);
+        // read all transactions from ByteBuffer
+        for (int k = 0; k < noOfTransactions; k++) {
+            // read version
+            int currentVersion = rawByteBuffer.getInt();
+            // read inCounter
+            byte[] currentInCounterVarInt = BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
+
+            long currentNoOfInputs = BitcoinUtil.getVarInt(currentInCounterVarInt);
+            boolean segwit = false;
+            byte marker = 1;
+            byte flag = 0;
+            // check segwit marker
+            if (currentNoOfInputs == 0) {
+                // this seems to be segwit - lets be sure
+                // check segwit flag
+                rawByteBuffer.mark();
+                byte segwitFlag = rawByteBuffer.get();
+                if (segwitFlag != 0) {
+                    // load the real number of inputs
+                    segwit = true;
+                    marker = 0;
+                    flag = segwitFlag;
+                    currentInCounterVarInt = BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
+                    currentNoOfInputs = BitcoinUtil.getVarInt(currentInCounterVarInt);
+                } else {
+                    LOG.warn("It seems a block with 0 transaction inputs was found");
+                    rawByteBuffer.reset();
+                }
+            }
+            // read inputs
+            List<BitcoinTransactionInput> currentTransactionInput = parseTransactionInputs(rawByteBuffer, currentNoOfInputs);
+
+            // read outCounter
+            byte[] currentOutCounterVarInt = BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
+            long currentNoOfOutput = BitcoinUtil.getVarInt(currentOutCounterVarInt);
+            // read outputs
+            List<BitcoinTransactionOutput> currentTransactionOutput = parseTransactionOutputs(rawByteBuffer, currentNoOfOutput);
+
+            List<BitcoinScriptWitnessItem> currentListOfTransactionSegwits;
+            if (segwit) {
+                // read segwit data
+                // for each transaction input there is at least some segwit data item
+                // read scriptWitness size
 
 
-/*
-* Parses the Bitcoin transaction inputs in a byte buffer. 
-*
-* @param rawByteBuffer ByteBuffer from which the transaction inputs have to be parsed
-* @param noOfTransactionInputs Number of expected transaction inputs
-*
-* @return Array of transactions
- * 
- */
-public List<BitcoinTransactionInput> parseTransactionInputs(ByteBuffer rawByteBuffer, long noOfTransactionInputs) {
-	ArrayList<BitcoinTransactionInput> currentTransactionInput = new ArrayList<>((int)noOfTransactionInputs);
-	
-	for (int i=0;i<noOfTransactionInputs;i++) {
-		// read previous Hash of Transaction
-		byte[] currentTransactionInputPrevTransactionHash=new byte[32];
-		rawByteBuffer.get(currentTransactionInputPrevTransactionHash,0,32);
-		// read previousTxOutIndex
-		long currentTransactionInputPrevTxOutIdx=BitcoinUtil.convertSignedIntToUnsigned(rawByteBuffer.getInt());
-		// read InScript length (Potential Internal Exceed Java Type)
-		byte[] currentTransactionTxInScriptLengthVarInt=BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
-		long currentTransactionTxInScriptSize=BitcoinUtil.getVarInt(currentTransactionTxInScriptLengthVarInt);
-		// read inScript
-		int currentTransactionTxInScriptSizeInt=(int)currentTransactionTxInScriptSize;
-		byte[] currentTransactionInScript=new byte[currentTransactionTxInScriptSizeInt];
-		rawByteBuffer.get(currentTransactionInScript,0,currentTransactionTxInScriptSizeInt);
-		// read sequence no
-		long currentTransactionInputSeqNo=BitcoinUtil.convertSignedIntToUnsigned(rawByteBuffer.getInt());
-		// add input
-		currentTransactionInput.add(new BitcoinTransactionInput(currentTransactionInputPrevTransactionHash,currentTransactionInputPrevTxOutIdx,currentTransactionTxInScriptLengthVarInt,currentTransactionInScript,currentTransactionInputSeqNo));	
-	}
-	return currentTransactionInput;
-}
-
-/*
-* Parses the Bitcoin transaction outputs in a byte buffer. 
-*
-* @param rawByteBuffer ByteBuffer from which the transaction outputs have to be parsed
-* @param noOfTransactionInputs Number of expected transaction outputs
-*
-* @return Array of transactions
- * 
- */
-public List<BitcoinTransactionOutput> parseTransactionOutputs(ByteBuffer rawByteBuffer, long noOfTransactionOutputs) {
-	ArrayList<BitcoinTransactionOutput> currentTransactionOutput = new ArrayList<>((int)(noOfTransactionOutputs));
-	for (int i=0;i<noOfTransactionOutputs;i++) {
-		// read value
-	
-		byte[] currentTransactionOutputValueArray = new byte[8];
-		rawByteBuffer.get(currentTransactionOutputValueArray);
-		BigInteger currentTransactionOutputValue = new BigInteger(1,EthereumUtil.reverseByteArray(currentTransactionOutputValueArray));
-		// read outScript length (Potential Internal Exceed Java Type)
-		byte[] currentTransactionTxOutScriptLengthVarInt=BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
-		long currentTransactionTxOutScriptSize=BitcoinUtil.getVarInt(currentTransactionTxOutScriptLengthVarInt);
-		int currentTransactionTxOutScriptSizeInt=(int)(currentTransactionTxOutScriptSize);
-		// read outScript
-		byte[] currentTransactionOutScript=new byte[currentTransactionTxOutScriptSizeInt];
-		rawByteBuffer.get(currentTransactionOutScript,0,currentTransactionTxOutScriptSizeInt);
-		currentTransactionOutput.add(new BitcoinTransactionOutput(currentTransactionOutputValue,currentTransactionTxOutScriptLengthVarInt,currentTransactionOutScript));
-	}
-	return currentTransactionOutput;
-}
-
-/*
-* Reads a raw Bitcoin block into a ByteBuffer. This method is recommended if you are only interested in a small part of the block and do not need the deserialization of the full block, ie in case you generally skip a lot of blocks
-*
-*
-* @return ByteBuffer containing the block
-*
-* @throws org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException in case of format errors of the Bitcoin Blockchain data
-**/
+                currentListOfTransactionSegwits = new ArrayList<>();
+                for (int i = 0; i < currentNoOfInputs; i++) {
+                    // get no of witness items for input
+                    byte[] currentWitnessCounterVarInt = BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
+                    long currentNoOfWitnesses = BitcoinUtil.getVarInt(currentWitnessCounterVarInt);
+                    List<BitcoinScriptWitness> currentTransactionSegwit = new ArrayList<>((int) currentNoOfWitnesses);
+                    for (int j = 0; j < (int) currentNoOfWitnesses; j++) {
+                        // read size of segwit script
+                        byte[] currentTransactionSegwitScriptLength = BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
+                        long currentTransactionSegwitScriptSize = BitcoinUtil.getVarInt(currentTransactionSegwitScriptLength);
+                        int currentTransactionSegwitScriptSizeInt = (int) currentTransactionSegwitScriptSize;
+                        // read segwit script
+                        byte[] currentTransactionInSegwitScript = new byte[currentTransactionSegwitScriptSizeInt];
+                        rawByteBuffer.get(currentTransactionInSegwitScript, 0, currentTransactionSegwitScriptSizeInt);
+                        // add segwit
+                        currentTransactionSegwit.add(new BitcoinScriptWitness(currentTransactionSegwitScriptLength, currentTransactionInSegwitScript));
+                    }
+                    currentListOfTransactionSegwits.add(new BitcoinScriptWitnessItem(currentWitnessCounterVarInt, currentTransactionSegwit));
+                }
+            } else {
+                currentListOfTransactionSegwits = new ArrayList<>();
+            }
+            // lock_time
+            int currentTransactionLockTime = rawByteBuffer.getInt();
+            // add transaction
+            resultTransactions.add(new BitcoinTransaction(marker, flag, currentVersion, currentInCounterVarInt, currentTransactionInput, currentOutCounterVarInt, currentTransactionOutput, currentListOfTransactionSegwits, currentTransactionLockTime));
+        }
+        return resultTransactions;
+    }
 
 
-public ByteBuffer readRawBlock() throws BitcoinBlockReadException {
-  try {
-	byte[] blockSizeByte = new byte[0];
-	while (blockSizeByte.length==0) { // in case of filtering by magic no we skip blocks until we reach a valid magicNo or end of Block
-		// check if more to read
-		if (this.bin.available()<1) {
-			return null;
-		}
-		blockSizeByte=skipBlocksNotInFilter();
-	}
-	// check if it is larger than maxsize, include 8 bytes for the magic and size header
-	long blockSize=BitcoinUtil.getSize(blockSizeByte)+8;
-	if (blockSize==0) {
-		throw new BitcoinBlockReadException("Error: Blocksize too small");
-	}
-	if (blockSize<0) {
-		throw new BitcoinBlockReadException("Error: This block size cannot be handled currently (larger then largest number in positive signed int)");
-	}
-	if (blockSize>this.maxSizeBitcoinBlock) {
-		throw new BitcoinBlockReadException("Error: Block size is larger then defined in configuration - Please increase it if this is a valid block");
-	}
-	// read full block into ByteBuffer
-	int blockSizeInt=(int)(blockSize);
-	byte[] fullBlock=new byte[blockSizeInt];
-	int totalByteRead=0;
-	int readByte;
-	while ((readByte=this.bin.read(fullBlock,totalByteRead,blockSizeInt-totalByteRead))>-1) {
-			totalByteRead+=readByte;
-			if (totalByteRead>=blockSize) {
-				break;
-			}
-	}
-	if (totalByteRead!=blockSize) {
-		 throw new BitcoinBlockReadException("Error: Could not read full block");
-	}
-	ByteBuffer result;
-	if (!(this.useDirectBuffer)) {
-	 	result=ByteBuffer.wrap(fullBlock);	
-	} else {
-		preAllocatedDirectByteBuffer.clear(); // clear out old bytebuffer
-		preAllocatedDirectByteBuffer.limit(fullBlock.length); // limit the bytebuffer
-		result=preAllocatedDirectByteBuffer;
-		result.put(fullBlock);
-		result.flip(); // put in read mode
-	}
-	result.order(ByteOrder.LITTLE_ENDIAN);	
-	return result;
-  } catch (IOException e) {
-	LOG.error(e);
-	throw new BitcoinBlockReadException(e.toString());
-  }
-}
+    /**
+     * Parses the Bitcoin transaction inputs in a byte buffer.
+     *
+     * @param rawByteBuffer ByteBuffer from which the transaction inputs have to be parsed
+     * @param noOfTransactionInputs Number of expected transaction inputs
+     *
+     * @return Array of transactions
+     *
+     */
+    public List<BitcoinTransactionInput> parseTransactionInputs(ByteBuffer rawByteBuffer, long noOfTransactionInputs) {
+        ArrayList<BitcoinTransactionInput> currentTransactionInput = new ArrayList<>((int) noOfTransactionInputs);
 
-/**
-* This function is used to read from a raw Bitcoin block some identifier. Note: Does not change ByteBuffer position
-*
-* @param rawByteBuffer ByteBuffer as read by readRawBlock
-* @return byte array containing hashMerkleRoot and prevHashBlock
-*
-*/
-public byte[] getKeyFromRawBlock (ByteBuffer rawByteBuffer)  {
-	rawByteBuffer.mark();
-	byte[] magicNo=new byte[4];
-	byte[] hashMerkleRoot=new byte[32];
-	byte[] hashPrevBlock=new byte[32];
-	// magic no (skip)
-	rawByteBuffer.get(magicNo,0,4);
-	// blocksize (skip)
-	rawByteBuffer.getInt();
-	// version (skip)
-	rawByteBuffer.getInt();
-	// hashPrevBlock
-	rawByteBuffer.get(hashPrevBlock,0,32);
-	// hashMerkleRoot
-	rawByteBuffer.get(hashMerkleRoot,0,32);
-	byte[] result=new byte[hashMerkleRoot.length+hashPrevBlock.length];
-	for (int i=0;i<hashMerkleRoot.length;i++) {
-		result[i]=hashMerkleRoot[i];
-	}
-	for (int j=0;j<hashPrevBlock.length;j++) {
-		result[j+hashMerkleRoot.length]=hashPrevBlock[j];
-	}
-	rawByteBuffer.reset();
-	return result;
-}
+        for (int i = 0; i < noOfTransactionInputs; i++) {
+            // read previous Hash of Transaction
+            byte[] currentTransactionInputPrevTransactionHash = new byte[32];
+            rawByteBuffer.get(currentTransactionInputPrevTransactionHash, 0, 32);
+            // read previousTxOutIndex
+            long currentTransactionInputPrevTxOutIdx = BitcoinUtil.convertSignedIntToUnsigned(rawByteBuffer.getInt());
+            // read InScript length (Potential Internal Exceed Java Type)
+            byte[] currentTransactionTxInScriptLengthVarInt = BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
+            long currentTransactionTxInScriptSize = BitcoinUtil.getVarInt(currentTransactionTxInScriptLengthVarInt);
+            // read inScript
+            int currentTransactionTxInScriptSizeInt = (int) currentTransactionTxInScriptSize;
+            byte[] currentTransactionInScript = new byte[currentTransactionTxInScriptSizeInt];
+            rawByteBuffer.get(currentTransactionInScript, 0, currentTransactionTxInScriptSizeInt);
+            // read sequence no
+            long currentTransactionInputSeqNo = BitcoinUtil.convertSignedIntToUnsigned(rawByteBuffer.getInt());
+            // add input
+            currentTransactionInput.add(new BitcoinTransactionInput(currentTransactionInputPrevTransactionHash, currentTransactionInputPrevTxOutIdx, currentTransactionTxInScriptLengthVarInt, currentTransactionInScript, currentTransactionInputSeqNo));
+        }
+        return currentTransactionInput;
+    }
 
-/**
-* Closes the reader
-*
-* @throws java.io.IOException in case of errors reading from the InputStream
-*
-*/
+    /**
+     * Parses the Bitcoin transaction outputs in a byte buffer.
+     *
+     * @param rawByteBuffer ByteBuffer from which the transaction outputs have to be parsed
+     * @param noOfTransactionOutputs Number of expected transaction outputs
+     *
+     * @return Array of transactions
+     *
+     */
+    public List<BitcoinTransactionOutput> parseTransactionOutputs(ByteBuffer rawByteBuffer, long noOfTransactionOutputs) {
+        ArrayList<BitcoinTransactionOutput> currentTransactionOutput = new ArrayList<>((int) (noOfTransactionOutputs));
+        for (int i = 0; i < noOfTransactionOutputs; i++) {
+            // read value
 
-public void close() throws IOException {
-	this.bin.close();
-}
+            byte[] currentTransactionOutputValueArray = new byte[8];
+            rawByteBuffer.get(currentTransactionOutputValueArray);
+            BigInteger currentTransactionOutputValue = new BigInteger(1, EthereumUtil.reverseByteArray(currentTransactionOutputValueArray));
+            // read outScript length (Potential Internal Exceed Java Type)
+            byte[] currentTransactionTxOutScriptLengthVarInt = BitcoinUtil.convertVarIntByteBufferToByteArray(rawByteBuffer);
+            long currentTransactionTxOutScriptSize = BitcoinUtil.getVarInt(currentTransactionTxOutScriptLengthVarInt);
+            int currentTransactionTxOutScriptSizeInt = (int) (currentTransactionTxOutScriptSize);
+            // read outScript
+            byte[] currentTransactionOutScript = new byte[currentTransactionTxOutScriptSizeInt];
+            rawByteBuffer.get(currentTransactionOutScript, 0, currentTransactionTxOutScriptSizeInt);
+            currentTransactionOutput.add(new BitcoinTransactionOutput(currentTransactionOutputValue, currentTransactionTxOutScriptLengthVarInt, currentTransactionOutScript));
+        }
+        return currentTransactionOutput;
+    }
 
+    /**
+     * Reads a raw Bitcoin block into a ByteBuffer. This method is recommended if you are only interested in a small part of the block and do not need the deserialization of the full block, ie in case you generally skip a lot of blocks
+     *
+     *
+     * @return ByteBuffer containing the block
+     *
+     * @throws org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException in case of format errors of the Bitcoin Blockchain data
+     **/
+    public ByteBuffer readRawBlock() throws BitcoinBlockReadException {
+        try {
+            byte[] blockSizeByte = new byte[0];
+            while (blockSizeByte.length == 0) { // in case of filtering by magic no we skip blocks until we reach a valid magicNo or end of Block
+                // check if more to read
+                if (this.bin.available() < 1) {
+                    return null;
+                }
+                blockSizeByte = skipBlocksNotInFilter();
+            }
+            // check if it is larger than maxsize, include 8 bytes for the magic and size header
+            long blockSize = BitcoinUtil.getSize(blockSizeByte) + 8;
+            if (blockSize == 0) {
+                throw new BitcoinBlockReadException("Error: Blocksize too small");
+            }
+            if (blockSize < 0) {
+                throw new BitcoinBlockReadException("Error: This block size cannot be handled currently (larger then largest number in positive signed int)");
+            }
+            if (blockSize > this.maxSizeBitcoinBlock) {
+                throw new BitcoinBlockReadException("Error: Block size is larger then defined in configuration - Please increase it if this is a valid block");
+            }
+            // read full block into ByteBuffer
+            int blockSizeInt = (int) (blockSize);
+            byte[] fullBlock = new byte[blockSizeInt];
+            int totalByteRead = 0;
+            int readByte;
+            while ((readByte = this.bin.read(fullBlock, totalByteRead, blockSizeInt - totalByteRead)) > -1) {
+                totalByteRead += readByte;
+                if (totalByteRead >= blockSize) {
+                    break;
+                }
+            }
+            if (totalByteRead != blockSize) {
+                throw new BitcoinBlockReadException("Error: Could not read full block");
+            }
+            ByteBuffer result;
+            if (!(this.useDirectBuffer)) {
+                result = ByteBuffer.wrap(fullBlock);
+            } else {
+                preAllocatedDirectByteBuffer.clear(); // clear out old bytebuffer
+                preAllocatedDirectByteBuffer.limit(fullBlock.length); // limit the bytebuffer
+                result = preAllocatedDirectByteBuffer;
+                result.put(fullBlock);
+                result.flip(); // put in read mode
+            }
+            result.order(ByteOrder.LITTLE_ENDIAN);
+            return result;
+        } catch (IOException e) {
+            LOG.error(e);
+            throw new BitcoinBlockReadException(e.toString());
+        }
+    }
 
-/*
-* Finds the start of a block by looking for the specified magics in the current InputStream
-*
-* @throws org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException in case of errors reading Blockchain data
-*
-*/
+    /**
+     * This function is used to read from a raw Bitcoin block some identifier. Note: Does not change ByteBuffer position
+     *
+     * @param rawByteBuffer ByteBuffer as read by readRawBlock
+     * @return byte array containing hashMerkleRoot and prevHashBlock
+     *
+     */
+    public byte[] getKeyFromRawBlock(ByteBuffer rawByteBuffer) {
+        rawByteBuffer.mark();
+        byte[] magicNo = new byte[4];
+        byte[] hashMerkleRoot = new byte[32];
+        byte[] hashPrevBlock = new byte[32];
+        // magic no (skip)
+        rawByteBuffer.get(magicNo, 0, 4);
+        // blocksize (skip)
+        rawByteBuffer.getInt();
+        // version (skip)
+        rawByteBuffer.getInt();
+        // hashPrevBlock
+        rawByteBuffer.get(hashPrevBlock, 0, 32);
+        // hashMerkleRoot
+        rawByteBuffer.get(hashMerkleRoot, 0, 32);
+        byte[] result = new byte[hashMerkleRoot.length + hashPrevBlock.length];
+        for (int i = 0; i < hashMerkleRoot.length; i++) {
+            result[i] = hashMerkleRoot[i];
+        }
+        for (int j = 0; j < hashPrevBlock.length; j++) {
+            result[j + hashMerkleRoot.length] = hashPrevBlock[j];
+        }
+        rawByteBuffer.reset();
+        return result;
+    }
 
-private void findMagic() throws BitcoinBlockReadException {
-	// search if first byte of any magic matches
-	// search up to maximum size of a bitcoin block
-	int currentSeek=0;
-	while(currentSeek!=this.maxSizeBitcoinBlock) {
-		int firstByte=-1;
-		try {
-			this.bin.mark(4); // magic is always 4 bytes
-			firstByte=this.bin.read();
-		} catch (IOException e) {
-			LOG.error(e);
-			throw new BitcoinBlockReadException(e.toString());
-		}
-		if (firstByte==-1) { 
-			throw new BitcoinBlockReadException("Error: Did not find defined magic within current stream");
-		}
-		try {
-			if (checkForMagicBytes(firstByte)) {
-				return;
-			}
-		} catch (IOException e) {
-			LOG.error(e);
-			throw new BitcoinBlockReadException(e.toString());
-		}
-		if (currentSeek==this.maxSizeBitcoinBlock) { 
-			throw new BitcoinBlockReadException("Error: Cannot seek to a block start, because no valid block found within the maximum size of a Bitcoin block. Check data or increase maximum size of Bitcoin block.");
-		}
-	// increase by one byte if magic not found yet
-		try {
-			this.bin.reset();
-			if (this.bin.skip(1)!=1) {
-				LOG.error("Error cannot skip 1 byte in InputStream");
-			}
-		} catch (IOException e) {
-			LOG.error(e);
-			throw new BitcoinBlockReadException(e.toString());
-		}
-	currentSeek++;
-	}
-}
-
-/*
-* Checks if there is a full Bitcoin Block at the current position of the InputStream
-*
-* @throws org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException in case of errors reading Blockchain data
-*
-*/
-
-private void checkFullBlock() throws BitcoinBlockReadException {
-	// now we can check that we have a full block
-		try {
-			this.bin.mark(this.maxSizeBitcoinBlock);
-			// skip maigc
-			long skipMagic=this.bin.skip(4);
-			if (skipMagic!=4) {
-				 throw new BitcoinBlockReadException("Error: Cannot seek to a block start, because no valid block found. Cannot skip forward magic");
-			}
-		}
-		catch (IOException e) {
-			LOG.error(e);
-			throw new BitcoinBlockReadException(e.toString());
-		}
-		// read size
-		// blocksize
-		byte[] blockSizeArray = new byte[4];
-		try {
-			
-			int maxByteRead=4;
-			int totalByteRead=0;
-			int readByte;
-			while ((readByte=this.bin.read(blockSizeArray,totalByteRead,maxByteRead-totalByteRead))>-1) {
-					totalByteRead+=readByte;
-					if (totalByteRead>=maxByteRead) {
-						break;
-					}
-			}
-			if (totalByteRead!=maxByteRead) {
-				throw new BitcoinBlockReadException("Error: Cannot seek to a block start, because no valid block found. Cannot read size of block");
-			} 
-		}
-		catch (IOException e) {
-			LOG.error(e);
-			throw new BitcoinBlockReadException(e.toString());
-		}		
-		long blockSize=BitcoinUtil.getSize(blockSizeArray);
-		if (this.maxSizeBitcoinBlock<blockSize) {
-			throw new BitcoinBlockReadException("Error: Cannot seek to a block start, because no valid block found. Max bitcoin block size is smaller than current block size.");
-		}
-		int blockSizeInt=(int)blockSize;
-		byte[] blockRead=new byte[blockSizeInt];
-		int totalByteRead=0;
-		int readByte;
-		try {
-		while ((readByte=this.bin.read(blockRead,totalByteRead,blockSizeInt-totalByteRead))>-1) {
-			totalByteRead+=readByte;
-			if (totalByteRead>=blockSize) { 
-				break;
-			}
-		}
-		} catch (IOException e) {
-			LOG.error(e);
-			throw new BitcoinBlockReadException(e.toString());
-		}
-		if (totalByteRead!=blockSize) {
-			 throw new BitcoinBlockReadException("Error: Cannot seek to a block start, because no valid block found. Cannot skip to end of block");
-		}
-		try {
-			this.bin.reset();
-		} catch (IOException e) {
-			LOG.error(e);
-			throw new BitcoinBlockReadException(e.toString());
-		}
-		// it is a full block
-}
+    /**
+     * Closes the reader
+     *
+     * @throws java.io.IOException in case of errors reading from the InputStream
+     *
+     */
+    public void close() throws IOException {
+        this.bin.close();
+    }
 
 
-/*
-* Skips blocks in inputStream which are not specified in the magic filter
-*
-* @return null or byte array containing the size of the block (not the block itself)
-*
-* @throws java.io.IOException in case of errors reading from InputStream
-*
-*/
-private byte[] skipBlocksNotInFilter() throws IOException {
-		byte[] magicNo=new byte[4];
-		byte[] blockSizeByte=new byte[4];
-		// mark bytestream so we can peak into it
-		this.bin.mark(8);
-		// read magic
-		int maxByteRead=4;
-		int totalByteRead=0;
-		int readByte;
-		while ((readByte=this.bin.read(magicNo,totalByteRead,maxByteRead-totalByteRead))>-1) {
-				totalByteRead+=readByte;
-				if (totalByteRead>=maxByteRead) {
-					break;
-				}
-		}
-		if (totalByteRead!=maxByteRead) {
-			return new byte[0];
-		} 
-		
-		// read blocksize
-	
-		maxByteRead=4;
-		totalByteRead=0;
-		while ((readByte=this.bin.read(blockSizeByte,totalByteRead,maxByteRead-totalByteRead))>-1) {
-				totalByteRead+=readByte;
-				if (totalByteRead>=maxByteRead) {
-					break;
-				}
-		}
-		if (totalByteRead!=maxByteRead) {
-			return new byte[0];
-		} 
-		
-		long blockSize=BitcoinUtil.getSize(blockSizeByte)+8;
-		// read the full block
-		this.bin.reset();
-		//filter by magic numbers?
-		if (filterSpecificMagic) {
-			for (int i=0;i<specificMagicByteArray.length;i++) {
-				byte[] currentFilter=specificMagicByteArray[i];
-				boolean doesMatchOneMagic=BitcoinUtil.compareMagics(currentFilter,magicNo);
-				// correspond to filter? read it!
-				if (doesMatchOneMagic) {
-					return blockSizeByte;
-				}
-			}
-			// Skip block if not found
-			if (this.bin.skip(blockSize)!=blockSize) {
-					LOG.error("Cannot skip block in InputStream");
-			}
-			return new byte[0];
-		
-		} else {
-			return blockSizeByte;
-		}
-}
+    /**
+     * Finds the start of a block by looking for the specified magics in the current InputStream
+     *
+     * @throws org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException in case of errors reading Blockchain data
+     *
+     */
+    private void findMagic() throws BitcoinBlockReadException {
+        // search if first byte of any magic matches
+        // search up to maximum size of a bitcoin block
+        int currentSeek = 0;
+        while (currentSeek != this.maxSizeBitcoinBlock) {
+            int firstByte = -1;
+            try {
+                this.bin.mark(4); // magic is always 4 bytes
+                firstByte = this.bin.read();
+            } catch (IOException e) {
+                LOG.error(e);
+                throw new BitcoinBlockReadException(e.toString());
+            }
+            if (firstByte == -1) {
+                throw new BitcoinBlockReadException("Error: Did not find defined magic within current stream");
+            }
+            try {
+                if (checkForMagicBytes(firstByte)) {
+                    return;
+                }
+            } catch (IOException e) {
+                LOG.error(e);
+                throw new BitcoinBlockReadException(e.toString());
+            }
+            if (currentSeek == this.maxSizeBitcoinBlock) {
+                throw new BitcoinBlockReadException("Error: Cannot seek to a block start, because no valid block found within the maximum size of a Bitcoin block. Check data or increase maximum size of Bitcoin block.");
+            }
+            // increase by one byte if magic not found yet
+            try {
+                this.bin.reset();
+                if (this.bin.skip(1) != 1) {
+                    LOG.error("Error cannot skip 1 byte in InputStream");
+                }
+            } catch (IOException e) {
+                LOG.error(e);
+                throw new BitcoinBlockReadException(e.toString());
+            }
+            currentSeek++;
+        }
+    }
 
-/**
-* Checks in BufferedInputStream (bin) for the magic(s) specified in specificMagicByteArray
-*
-* @param firstByte first byte (as int) of the byteBuffer
-*
-* @retrun true if one of the magics has been identified, false if not
-*
-* @throws java.io.IOException in case of issues reading from BufferedInputStream
-*
-*/
+    /**
+     * Checks if there is a full Bitcoin Block at the current position of the InputStream
+     *
+     * @throws org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException in case of errors reading Blockchain data
+     *
+     */
+    private void checkFullBlock() throws BitcoinBlockReadException {
+        // now we can check that we have a full block
+        try {
+            this.bin.mark(this.maxSizeBitcoinBlock);
+            // skip maigc
+            long skipMagic = this.bin.skip(4);
+            if (skipMagic != 4) {
+                throw new BitcoinBlockReadException("Error: Cannot seek to a block start, because no valid block found. Cannot skip forward magic");
+            }
+        } catch (IOException e) {
+            LOG.error(e);
+            throw new BitcoinBlockReadException(e.toString());
+        }
+        // read size
+        // blocksize
+        byte[] blockSizeArray = new byte[4];
+        try {
 
-private boolean checkForMagicBytes(int firstByte) throws IOException {
-	byte[] fullMagic=null;
-		for (int i=0;i<this.specificMagicByteArray.length;i++) {
-			// compare first byte and decide if we want to read full magic
-			int currentMagicFirstbyte=this.specificMagicByteArray[i][0] & 0xFF;
-			if (firstByte==currentMagicFirstbyte) {
-				if (fullMagic==null) { // read full magic
-					fullMagic=new byte[4];
-					fullMagic[0]=this.specificMagicByteArray[i][0];
-					int maxByteRead=4;
-					int totalByteRead=1;
-					int readByte;
-					while ((readByte=this.bin.read(fullMagic,totalByteRead,maxByteRead-totalByteRead))>-1) {
-							totalByteRead+=readByte;
-							if (totalByteRead>=maxByteRead) {
-								break;
-							}
-					}
-					if (totalByteRead!=maxByteRead) {
-						return false;
-					} 
-				}
-				// compare full magics
-				if (BitcoinUtil.compareMagics(fullMagic,this.specificMagicByteArray[i])) {
-					this.bin.reset();
-					return true;
-				}
-			}
-				
-			} 
-	return false;
-}
+            int maxByteRead = 4;
+            int totalByteRead = 0;
+            int readByte;
+            while ((readByte = this.bin.read(blockSizeArray, totalByteRead, maxByteRead - totalByteRead)) > -1) {
+                totalByteRead += readByte;
+                if (totalByteRead >= maxByteRead) {
+                    break;
+                }
+            }
+            if (totalByteRead != maxByteRead) {
+                throw new BitcoinBlockReadException("Error: Cannot seek to a block start, because no valid block found. Cannot read size of block");
+            }
+        } catch (IOException e) {
+            LOG.error(e);
+            throw new BitcoinBlockReadException(e.toString());
+        }
+        long blockSize = BitcoinUtil.getSize(blockSizeArray);
+        if (this.maxSizeBitcoinBlock < blockSize) {
+            throw new BitcoinBlockReadException("Error: Cannot seek to a block start, because no valid block found. Max bitcoin block size is smaller than current block size.");
+        }
+        int blockSizeInt = (int) blockSize;
+        byte[] blockRead = new byte[blockSizeInt];
+        int totalByteRead = 0;
+        int readByte;
+        try {
+            while ((readByte = this.bin.read(blockRead, totalByteRead, blockSizeInt - totalByteRead)) > -1) {
+                totalByteRead += readByte;
+                if (totalByteRead >= blockSize) {
+                    break;
+                }
+            }
+        } catch (IOException e) {
+            LOG.error(e);
+            throw new BitcoinBlockReadException(e.toString());
+        }
+        if (totalByteRead != blockSize) {
+            throw new BitcoinBlockReadException("Error: Cannot seek to a block start, because no valid block found. Cannot skip to end of block");
+        }
+        try {
+            this.bin.reset();
+        } catch (IOException e) {
+            LOG.error(e);
+            throw new BitcoinBlockReadException(e.toString());
+        }
+        // it is a full block
+    }
+
+    /**
+     * Skips blocks in inputStream which are not specified in the magic filter
+     *
+     * @return null or byte array containing the size of the block (not the block itself)
+     *
+     * @throws java.io.IOException in case of errors reading from InputStream
+     *
+     */
+    private byte[] skipBlocksNotInFilter() throws IOException {
+        byte[] magicNo = new byte[4];
+        byte[] blockSizeByte = new byte[4];
+        // mark bytestream so we can peak into it
+        this.bin.mark(8);
+        // read magic
+        int maxByteRead = 4;
+        int totalByteRead = 0;
+        int readByte;
+        while ((readByte = this.bin.read(magicNo, totalByteRead, maxByteRead - totalByteRead)) > -1) {
+            totalByteRead += readByte;
+            if (totalByteRead >= maxByteRead) {
+                break;
+            }
+        }
+        if (totalByteRead != maxByteRead) {
+            return new byte[0];
+        }
+
+        // read blocksize
+
+        maxByteRead = 4;
+        totalByteRead = 0;
+        while ((readByte = this.bin.read(blockSizeByte, totalByteRead, maxByteRead - totalByteRead)) > -1) {
+            totalByteRead += readByte;
+            if (totalByteRead >= maxByteRead) {
+                break;
+            }
+        }
+        if (totalByteRead != maxByteRead) {
+            return new byte[0];
+        }
+
+        long blockSize = BitcoinUtil.getSize(blockSizeByte) + 8;
+        // read the full block
+        this.bin.reset();
+        //filter by magic numbers?
+        if (filterSpecificMagic) {
+            for (int i = 0; i < specificMagicByteArray.length; i++) {
+                byte[] currentFilter = specificMagicByteArray[i];
+                boolean doesMatchOneMagic = BitcoinUtil.compareMagics(currentFilter, magicNo);
+                // correspond to filter? read it!
+                if (doesMatchOneMagic) {
+                    return blockSizeByte;
+                }
+            }
+            // Skip block if not found
+            if (this.bin.skip(blockSize) != blockSize) {
+                LOG.error("Cannot skip block in InputStream");
+            }
+            return new byte[0];
+
+        } else {
+            return blockSizeByte;
+        }
+    }
+
+    /**
+     * Checks in BufferedInputStream (bin) for the magic(s) specified in specificMagicByteArray
+     *
+     * @param firstByte first byte (as int) of the byteBuffer
+     *
+     * @retrun true if one of the magics has been identified, false if not
+     *
+     * @throws java.io.IOException in case of issues reading from BufferedInputStream
+     *
+     */
+    private boolean checkForMagicBytes(int firstByte) throws IOException {
+        byte[] fullMagic = null;
+        for (int i = 0; i < this.specificMagicByteArray.length; i++) {
+            // compare first byte and decide if we want to read full magic
+            int currentMagicFirstbyte = this.specificMagicByteArray[i][0] & 0xFF;
+            if (firstByte == currentMagicFirstbyte) {
+                if (fullMagic == null) { // read full magic
+                    fullMagic = new byte[4];
+                    fullMagic[0] = this.specificMagicByteArray[i][0];
+                    int maxByteRead = 4;
+                    int totalByteRead = 1;
+                    int readByte;
+                    while ((readByte = this.bin.read(fullMagic, totalByteRead, maxByteRead - totalByteRead)) > -1) {
+                        totalByteRead += readByte;
+                        if (totalByteRead >= maxByteRead) {
+                            break;
+                        }
+                    }
+                    if (totalByteRead != maxByteRead) {
+                        return false;
+                    }
+                }
+                // compare full magics
+                if (BitcoinUtil.compareMagics(fullMagic, this.specificMagicByteArray[i])) {
+                    this.bin.reset();
+                    return true;
+                }
+            }
+
+        }
+        return false;
+    }
 
 
 }

--- a/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/common/LittleEndianUInt32.java
+++ b/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/common/LittleEndianUInt32.java
@@ -1,0 +1,69 @@
+package org.zuinnote.hadoop.bitcoin.format.common;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * An implementation of an unsigned 32-bit integer in Java.
+ */
+public class LittleEndianUInt32 extends Number {
+
+    public static final int NUM_BYTES = 4;
+    public static final long MAX = (1L<<(NUM_BYTES*8)) - 1;
+
+    protected ByteBuffer rawData;
+
+    public LittleEndianUInt32() {
+        this.rawData = ByteBuffer.allocate(NUM_BYTES);
+        this.rawData.order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    public LittleEndianUInt32(byte[] value) {
+        this();
+        setValue(value);
+    }
+
+    public LittleEndianUInt32(long value) {
+        this();
+        setValue(value);
+    }
+
+    public long getValue() {
+        long value = rawData.getInt(0);
+        if (value < 0) {
+            return MAX+1+value;
+        } else {
+            return value;
+        }
+    }
+
+    public void setValue(long value) {
+        rawData.putInt(0, (int) value);
+    }
+
+    public void setValue(byte[] value) {
+        rawData.put(value, 0, NUM_BYTES);
+    }
+
+    @Override
+    public int intValue() {
+        int result = (int) getValue();
+        if (result < 0) throw new IllegalArgumentException("unsigned int overflow");
+        return result;
+    }
+
+    @Override
+    public long longValue() {
+        return getValue();
+    }
+
+    @Override
+    public float floatValue() {
+        return (float) getValue();
+    }
+
+    @Override
+    public double doubleValue() {
+        return (double) getValue();
+    }
+}

--- a/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/common/LittleEndianUInt32.java
+++ b/inputformat/src/main/java/org/zuinnote/hadoop/bitcoin/format/common/LittleEndianUInt32.java
@@ -5,12 +5,19 @@ import java.nio.ByteOrder;
 
 /**
  * An implementation of an unsigned 32-bit integer in Java.
+ *
+ * The value is stored in a raw little-endian four-byte buffer, and then converted
+ * to a 64-bit signed long on-demand.  This allows UINT32 values  to be stored efficiently
+ * for big-data computations while retaining the full range of positive values.
  */
 public class LittleEndianUInt32 extends Number {
 
     public static final int NUM_BYTES = 4;
     public static final long MAX = (1L<<(NUM_BYTES*8)) - 1;
 
+    /**
+     * The raw data stored as 4 bytes in little-endian order.
+     */
     protected ByteBuffer rawData;
 
     public LittleEndianUInt32() {
@@ -24,6 +31,11 @@ public class LittleEndianUInt32 extends Number {
     }
 
     public LittleEndianUInt32(long value) {
+        this();
+        setValue(value);
+    }
+
+    public LittleEndianUInt32(ByteBuffer value) {
         this();
         setValue(value);
     }
@@ -45,10 +57,16 @@ public class LittleEndianUInt32 extends Number {
         rawData.put(value, 0, NUM_BYTES);
     }
 
+    public void setValue(ByteBuffer buffer) {
+        for(int i=0; i<NUM_BYTES; i++) {
+           rawData.put(i, buffer.get());
+        }
+    }
+
     @Override
     public int intValue() {
         int result = (int) getValue();
-        if (result < 0) throw new IllegalArgumentException("unsigned int overflow");
+        if (result < 0) throw new IllegalArgumentException("signed int overflow");
         return result;
     }
 
@@ -66,4 +84,5 @@ public class LittleEndianUInt32 extends Number {
     public double doubleValue() {
         return (double) getValue();
     }
+
 }

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
@@ -49,7 +49,7 @@ public class BitcoinFormatReaderTest {
                 "reqseekversion1.blk", "testnet3genesis.blk", "testnet3version4.blk", "testnet3version4.blk",
                 "multinet.blk", "scriptwitness.blk", "scriptwitness2.blk"};
         for(String fileName: testFiles) {
-            testAvailable(fileName);
+            assertTestFileAvailable(fileName);
         }
     }
 
@@ -217,22 +217,6 @@ public class BitcoinFormatReaderTest {
         }
     }
 
-    public void checkDateField(Calendar expected, Calendar actual, int field) {
-        assertEquals(expected.get(field), actual.get(field));
-    }
-
-    public void checkDate(Date expected, Date actual) {
-        Calendar x = new GregorianCalendar();
-        x.setTime(expected);
-        Calendar y = new GregorianCalendar();
-        y.setTime(actual);
-        Integer[] fields = new Integer[]
-            {Calendar.YEAR, Calendar.MONTH, Calendar.DAY_OF_MONTH, Calendar.HOUR_OF_DAY, Calendar.MINUTE};
-        for(int field : fields) {
-            checkDateField(x, y, field);
-        }
-    }
-
     @Test
     public void parseGenesisBlockTestTime() throws IOException, BitcoinBlockReadException, ParseException {
         BitcoinBlockReader bbr = null;
@@ -242,7 +226,7 @@ public class BitcoinFormatReaderTest {
             SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd h:m:s");
             Date genesisDate = format.parse ( "2009-01-03 18:15:05" );
             Date blockDate = new java.util.Date(genesisBlock.getTime()*1000L);
-            checkDate(genesisDate, blockDate);
+            assertDateFieldsEqual(genesisDate, blockDate);
         } finally {
             if (bbr != null) {
                 bbr.close();
@@ -807,13 +791,6 @@ public class BitcoinFormatReaderTest {
         return Objects.requireNonNull(getClass().getClassLoader().getResource("testdata/" + fileName)).getFile();
     }
 
-    public void testAvailable(String fileName) {
-        String fullFilename = getFullFilename(fileName);
-        File file = new File(fullFilename);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
     public BitcoinBlockReader blockReader(String fileName, boolean direct) throws IOException {
         return blockReader(fileName, direct, DEFAULT_MAGIC);
     }
@@ -826,6 +803,29 @@ public class BitcoinFormatReaderTest {
 
     public BitcoinBlockReader genesisBlockReader(boolean direct) throws IOException {
         return blockReader("genesis.blk", direct);
+    }
+
+    public void assertTestFileAvailable(String fileName) {
+        String fullFilename = getFullFilename(fileName);
+        File file = new File(fullFilename);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    public void assertDateFieldEqual(Calendar expected, Calendar actual, int field) {
+        assertEquals(expected.get(field), actual.get(field));
+    }
+
+    public void assertDateFieldsEqual(Date expected, Date actual) {
+        Calendar x = new GregorianCalendar();
+        x.setTime(expected);
+        Calendar y = new GregorianCalendar();
+        y.setTime(actual);
+        Integer[] fields = new Integer[]
+                {Calendar.YEAR, Calendar.MONTH, Calendar.DAY_OF_MONTH, Calendar.HOUR_OF_DAY, Calendar.MINUTE};
+        for(int field : fields) {
+            assertDateFieldEqual(x, y, field);
+        }
     }
 
 }

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
@@ -388,7 +388,7 @@ public class BitcoinFormatReaderTest {
 
 
     @Test
-    public void parseGenesisBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+    public void parseGenesisBlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         ClassLoader classLoader = getClass().getClassLoader();
         String fileName = "genesis.blk";
         String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
@@ -225,7 +225,7 @@ public class BitcoinFormatReaderTest {
             BitcoinBlock genesisBlock = bbr.readBlock();
             SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd h:m:s");
             Date genesisDate = format.parse ( "2009-01-03 18:15:05" );
-            Date blockDate = new java.util.Date(genesisBlock.getTime()*1000L);
+            Date blockDate = genesisBlock.getDate();
             assertDateFieldsEqual(genesisDate, blockDate);
         } finally {
             if (bbr != null) {

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
@@ -17,11 +17,8 @@
 package org.zuinnote.hadoop.bitcoin.format.common;
 
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -30,1168 +27,1184 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 
-import org.junit.jupiter.api.Test;
-import org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class BitcoinFormatReaderTest {
-static final int DEFAULT_BUFFERSIZE=64*1024;
-static final int DEFAULT_MAXSIZE_BITCOINBLOCK=8 * 1024 * 1024;
-static final byte[][] DEFAULT_MAGIC = {{(byte)0xF9,(byte)0xBE,(byte)0xB4,(byte)0xD9}};
-private static final byte[][] TESTNET3_MAGIC = {{(byte)0x0B,(byte)0x11,(byte)0x09,(byte)0x07}};
-private static final byte[][] MULTINET_MAGIC = {{(byte)0xF9,(byte)0xBE,(byte)0xB4,(byte)0xD9},{(byte)0x0B,(byte)0x11,(byte)0x09,(byte)0x07}};
+    static final int DEFAULT_BUFFERSIZE = 64 * 1024;
+    static final int DEFAULT_MAXSIZE_BITCOINBLOCK = 8 * 1024 * 1024;
+    static final byte[][] DEFAULT_MAGIC = {{(byte) 0xF9, (byte) 0xBE, (byte) 0xB4, (byte) 0xD9}};
+    private static final byte[][] TESTNET3_MAGIC = {{(byte) 0x0B, (byte) 0x11, (byte) 0x09, (byte) 0x07}};
+    private static final byte[][] MULTINET_MAGIC = {{(byte) 0xF9, (byte) 0xBE, (byte) 0xB4, (byte) 0xD9}, {(byte) 0x0B, (byte) 0x11, (byte) 0x09, (byte) 0x07}};
 
- @Test
-  public void checkTestDataGenesisBlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
-
- @Test
-  public void checkTestDataVersion1BlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version1.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
- @Test
-  public void checkTestDataVersion2BlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version2.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
-
- @Test
-  public void checkTestDataVersion3BlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version3.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
- @Test
-  public void checkTestDataVersion4BlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version4.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
- @Test
-  public void checkTestDataVersion1SeekBlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="reqseekversion1.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
- @Test
-  public void checkTestDataTestnet3GenesisBlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
-
- @Test
-  public void checkTestDataTestnet3Version4BlockAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3version4.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
-
-
-
- @Test
-  public void checkTestDataMultiNetAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="multinet.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
-  }
- 
- @Test
- public void checkTestDataScriptWitnessNetAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
- }
- 
- @Test
- public void checkTestDataScriptWitness2NetAvailable() {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness2.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	assertNotNull(fileNameGenesis,"Test Data File \""+fileName+"\" is not null in resource path");
-	File file = new File(fileNameGenesis);
-	assertTrue( file.exists(),"Test Data File \""+fileName+"\" exists");
-	assertFalse( file.isDirectory(),"Test Data File \""+fileName+"\" is not a directory");
- }
-
-
-
-  @Test
-  public void parseGenesisBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer genesisByteBuffer = bbr.readRawBlock();
-		assertFalse( genesisByteBuffer.isDirect(),"Raw Genesis Block is HeapByteBuffer");
-		assertEquals( 293, genesisByteBuffer.limit(),"Raw Genesis block has a size of 293 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion1BlockAsBitcoinRawBlockHeap()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version1.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version1ByteBuffer = bbr.readRawBlock();
-		assertFalse( version1ByteBuffer.isDirect(),"Random Version 1 Raw Block is HeapByteBuffer");
-		assertEquals( 482, version1ByteBuffer.limit(),"Random Version 1 Raw Block has a size of 482 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion2BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version2.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version2ByteBuffer = bbr.readRawBlock();
-		assertFalse( version2ByteBuffer.isDirect(),"Random Version 2 Raw Block is HeapByteBuffer");
-		assertEquals( 191198, version2ByteBuffer.limit(),"Random Version 2 Raw Block has a size of 191.198 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-
-  @Test
-  public void parseVersion3BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version3.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version3ByteBuffer = bbr.readRawBlock();
-		assertFalse( version3ByteBuffer.isDirect(),"Random Version 3 Raw Block is HeapByteBuffer");
-		assertEquals( 932199, version3ByteBuffer.limit(),"Random Version 3 Raw Block has a size of 932.199 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion4BlockAsBitcoinRawBlockHeap()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version4.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version4ByteBuffer = bbr.readRawBlock();
-		assertFalse( version4ByteBuffer.isDirect(),"Random Version 4 Raw Block is HeapByteBuffer");
-		assertEquals( 998039, version4ByteBuffer.limit(),"Random Version 4 Raw Block has a size of 998.039 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-  public void parseTestNet3GenesisBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		ByteBuffer genesisByteBuffer = bbr.readRawBlock();
-		assertFalse( genesisByteBuffer.isDirect(),"Raw TestNet3 Genesis Block is HeapByteBuffer");
-		assertEquals( 293, genesisByteBuffer.limit(),"Raw TestNet3 Genesis block has a size of 293 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseTestNet3Version4BlockAsBitcoinRawBlockHeap()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3version4.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		ByteBuffer version4ByteBuffer = bbr.readRawBlock();
-		assertFalse( version4ByteBuffer.isDirect(),"Random TestNet3 Version 4 Raw Block is HeapByteBuffer");
-		assertEquals( 749041, version4ByteBuffer.limit(),"Random TestNet3 Version 4 Raw Block has a size of 749.041 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-
-@Test
-  public void parseMultiNetAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="multinet.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.MULTINET_MAGIC,direct);
-		ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
-		assertFalse( firstMultinetByteBuffer.isDirect(),"First MultiNetBlock is HeapByteBuffer");
-		assertEquals( 293, firstMultinetByteBuffer.limit(),"First MultiNetBlock has a size of 293 bytes");
-		ByteBuffer secondMultinetByteBuffer = bbr.readRawBlock();
-		assertFalse( secondMultinetByteBuffer.isDirect(),"Second MultiNetBlock is HeapByteBuffer");
-		assertEquals( 191198, secondMultinetByteBuffer.limit(),"Second MultiNetBlock has a size of 191.198 bytes");
-		ByteBuffer thirdMultinetByteBuffer = bbr.readRawBlock();
-		assertFalse( thirdMultinetByteBuffer.isDirect(),"Third MultiNetBlock is HeapByteBuffer");
-		assertEquals( 749041, thirdMultinetByteBuffer.limit(),"Third MultiNetBlock has a size of 749.041 bytes");
-
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-public void parseScriptWitnessBlockAsBitcoinRawBlockHeap()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-  ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
-		assertFalse( scriptwitnessByteBuffer.isDirect(),"Random ScriptWitness Raw Block is HeapByteBuffer");
-		assertEquals( 999283, scriptwitnessByteBuffer.limit(),"Random ScriptWitness Raw Block has a size of 999283 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
-
-
-@Test
-public void parseScriptWitness2BlockAsBitcoinRawBlockHeap()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-  ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness2.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
-		assertFalse( scriptwitnessByteBuffer.isDirect(),"Random ScriptWitness Raw Block is HeapByteBuffer");
-		assertEquals( 1000039, scriptwitnessByteBuffer.limit(),"Random ScriptWitness Raw Block has a size of 1000039 bytes");		
-		scriptwitnessByteBuffer = bbr.readRawBlock();
-		assertFalse( scriptwitnessByteBuffer.isDirect(),"Random ScriptWitness Raw Block is HeapByteBuffer");
-		assertEquals( 999312, scriptwitnessByteBuffer.limit(),"Random ScriptWitness Raw Block has a size of 999312 bytes");		
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
-
-
-  @Test
-  public void parseGenesisBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer genesisByteBuffer = bbr.readRawBlock();
-		assertTrue( genesisByteBuffer.isDirect(),"Raw Genesis Block is DirectByteBuffer");
-		assertEquals( 293, genesisByteBuffer.limit(),"Raw Genesis Block has a size of 293 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion1BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version1.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version1ByteBuffer = bbr.readRawBlock();
-		assertTrue( version1ByteBuffer.isDirect(),"Random Version 1 Raw Block is DirectByteBuffer");
-		assertEquals( 482, version1ByteBuffer.limit(),"Random Version 1 Raw Block has a size of 482 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion2BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version2.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version2ByteBuffer = bbr.readRawBlock();
-		assertTrue( version2ByteBuffer.isDirect(),"Random Version 2 Raw Block is DirectByteBuffer");
-		assertEquals( 191198, version2ByteBuffer.limit(),"Random Version 2 Raw Block has a size of 191.198 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion3BlockAsBitcoinRawBlockDirect()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version3.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version3ByteBuffer = bbr.readRawBlock();
-		assertTrue( version3ByteBuffer.isDirect(),"Random Version 3 Raw Block is DirectByteBuffer");
-		assertEquals( 932199, version3ByteBuffer.limit(),"Random Version 3 Raw Block has a size of 932.199 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion4BlockAsBitcoinRawBlockDirect()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version4.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer version4ByteBuffer = bbr.readRawBlock();
-		assertTrue( version4ByteBuffer.isDirect(),"Random Version 4 Raw Block is DirectByteBuffer");
-		assertEquals( 998039, version4ByteBuffer.limit(),"Random Version 4 Raw Block has a size of 998.039 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-  public void parseTestNet3GenesisBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		ByteBuffer genesisByteBuffer = bbr.readRawBlock();
-		assertTrue( genesisByteBuffer.isDirect(),"Raw TestNet3 Genesis Block is DirectByteBuffer");
-		assertEquals( 293, genesisByteBuffer.limit(),"Raw TestNet3 Genesis block has a size of 293 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseTestNet3Version4BlockAsBitcoinRawBlockDirect()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3version4.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		ByteBuffer version4ByteBuffer = bbr.readRawBlock();
-		assertTrue( version4ByteBuffer.isDirect(),"Random TestNet3 Version 4 Raw Block is DirectByteBuffer");
-		assertEquals( 749041, version4ByteBuffer.limit(),"Random TestNet3  Version 4 Raw Block has a size of 749.041 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-  public void parseMultiNetAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="multinet.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.MULTINET_MAGIC,direct);
-		ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
-		assertTrue( firstMultinetByteBuffer.isDirect(),"First MultiNetBlock is DirectByteBuffer");
-		assertEquals( 293, firstMultinetByteBuffer.limit(),"First MultiNetBlock has a size of 293 bytes");
-		ByteBuffer secondMultinetByteBuffer = bbr.readRawBlock();
-		assertTrue( secondMultinetByteBuffer.isDirect(),"Second MultiNetBlock is DirectByteBuffer");
-		assertEquals( 191198, secondMultinetByteBuffer.limit(),"Second MultiNetBlock has a size of 191.198 bytes");
-		ByteBuffer thirdMultinetByteBuffer = bbr.readRawBlock();
-		assertTrue( thirdMultinetByteBuffer.isDirect(),"Third MultiNetBlock is DirectByteBuffer");
-		assertEquals( 749041, thirdMultinetByteBuffer.limit(),"Third MultiNetBlock has a size of 749.041 bytes");
-
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-public void parseScriptWitnessBlockAsBitcoinRawBlockDirect()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-  ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
-		assertTrue( scriptwitnessByteBuffer.isDirect(),"Random ScriptWitness Raw Block is DirectByteBuffer");
-		assertEquals( 999283, scriptwitnessByteBuffer.limit(),"Random ScriptWitness Raw Block has a size of 999283 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
-
-@Test
-public void parseScriptWitness2BlockAsBitcoinRawBlockDirect()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-  ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness2.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
-		assertTrue( scriptwitnessByteBuffer.isDirect(),"Random ScriptWitness Raw Block is DirectByteBuffer");
-		assertEquals( 1000039, scriptwitnessByteBuffer.limit(),"Random ScriptWitness Raw Block has a size of 1000039 bytes");		
-		scriptwitnessByteBuffer = bbr.readRawBlock();
-		assertTrue( scriptwitnessByteBuffer.isDirect(),"Random ScriptWitness Raw Block is DirectByteBuffer");
-		assertEquals( 999312, scriptwitnessByteBuffer.limit(),"Random ScriptWitness Raw Block has a size of 999312 bytes");		
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
-
-
-
-  @Test
-  public void parseGenesisBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 1, theBitcoinBlock.getTransactions().size(),"Genesis Block must contain exactly one transaction");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Genesis Block must contain exactly one transaction with one input");
-		assertEquals( 77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Genesis Block must contain exactly one transaction with one input and script length 77");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Genesis Block must contain exactly one transaction with one output");
-		assertEquals( BigInteger.valueOf(5000000000L),theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getValue(), "Value must be BigInteger corresponding to 5000000000L");
-		assertEquals( 67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Genesis Block must contain exactly one transaction with one output and script length 67");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-
-  @Test
-  public void parseTestNet3GenesisBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3genesis.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 1, theBitcoinBlock.getTransactions().size(),"TestNet3 Genesis Block must contain exactly one transaction");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"TestNet3 Genesis Block must contain exactly one transaction with one input");
-		assertEquals( 77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"TestNet3 Genesis Block must contain exactly one transaction with one input and script length 77");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"TestNet3 Genesis Block must contain exactly one transaction with one output");
-		assertEquals( 67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"TestNet3 Genesis Block must contain exactly one transaction with one output and script length 67");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion1BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version1.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 2, theBitcoinBlock.getTransactions().size(),"Random Version 1 Block must contain exactly two transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 1 Block must contain exactly two transactions of which the first has one input");
-		assertEquals( 8, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 1 Block must contain exactly two transactions of which the first has one input and script length 8");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 1 Block must contain exactly two transactions of which the first has one output");
-		assertEquals( 67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 1 Block must contain exactly two transactions of which the first has one output and script length 67");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion2BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version2.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 343, theBitcoinBlock.getTransactions().size(),"Random Version 2 Block must contain exactly 343 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
-		assertEquals( 40, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 2 Block must contain exactly 343 transactions of which the first has one input and script length 40");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 2 Block must contain exactly 343 transactions of which the first has one output");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 2 Block must contain exactly 343 transactions of which the first has one output and script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion3BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+    @Test
+    public void checkTestDataGenesisBlockAvailable() {
         ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version3.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 1645, theBitcoinBlock.getTransactions().size(),"Random Version 3 Block must contain exactly 1645 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
-		assertEquals( 49, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 3 Block must contain exactly 1645 transactions of which the first has one input and script length 49");
-		assertEquals( 2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 3 Block must contain exactly 1645 transactions of which the first has two outputs");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 3 Block must contain exactly 1645 transactions of which the first has two output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion4BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-            ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version4.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 936, theBitcoinBlock.getTransactions().size(),"Random Version 4 Block must contain exactly 936 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
-		assertEquals( 4, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 4 Block must contain exactly 936 transactions of which the first has one input and script length 4");
-		assertEquals( 2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 4 Block must contain exactly 936 transactions of which the first has two outputs");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 4 Block must contain exactly 936 transactions of which the first has two output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseTestNet3Version4BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-            ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3version4.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 3299, theBitcoinBlock.getTransactions().size(),"Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
-		assertEquals( 35, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input and script length 35");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one outputs");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-  public void parseMultiNetBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="multinet.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.MULTINET_MAGIC,direct);
-		BitcoinBlock firstBitcoinBlock = bbr.readBlock();
-		assertEquals( 1, firstBitcoinBlock.getTransactions().size(),"First MultiNet Block must contain exactly one transaction");
-		assertEquals( 1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"First MultiNet Block must contain exactly one transaction with one input");
-		assertEquals( 77, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"First MultiNet Block must contain exactly one transaction with one input and script length 77");
-		assertEquals( 1, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"First MultiNet Block must contain exactly one transaction with one output");
-		assertEquals( 67, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"First MultiNet Block must contain exactly one transaction with one output and script length 67");
-		BitcoinBlock secondBitcoinBlock = bbr.readBlock();
-		assertEquals( 343, secondBitcoinBlock.getTransactions().size(),"Second MultiNet Block must contain exactly 343 transactions");
-		assertEquals( 1, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Second MultiNet Block must contain exactly 343 transactions of which the first has one input");
-		assertEquals( 40, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Second MultiNet Block must contain exactly 343 transactions of which the first has one input and script length 40");
-		assertEquals( 1, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Second MultiNet Block must contain exactly 343 transactions of which the first has one output");
-		assertEquals( 25, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Second MultiNet Block must contain exactly 343 transactions of which the first has one output and script length 25");
-		BitcoinBlock thirdBitcoinBlock = bbr.readBlock();
-		assertEquals( 3299, thirdBitcoinBlock.getTransactions().size(),"Third MultiNet Block must contain exactly 3299 transactions");
-		assertEquals( 1, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Third MultiNet Block must contain exactly 3299 transactions of which the first has one input");
-		assertEquals( 35, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Third MultiNet Block must contain exactly 3299 transactions of which the first has one input and script length 35");
-		assertEquals( 1, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Third MultiNet Block must contain exactly 3299 transactions of which the first has one outputs");
-		assertEquals( 25, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Third MultiNet Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-@Test
-public void parseScriptWitnessBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 470, theBitcoinBlock.getTransactions().size(),"Random ScriptWitness Block must contain exactly 470 transactions");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
+        String fileName = "genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
 
 
-@Test
-public void parseScriptWitness2BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness2.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 2191, theBitcoinBlock.getTransactions().size(),"First random ScriptWitness Block must contain exactly 2191 transactions");
-		theBitcoinBlock = bbr.readBlock();
-		assertEquals( 2508, theBitcoinBlock.getTransactions().size(),"Second random ScriptWitness Block must contain exactly 2508 transactions");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
-
-  @Test
-  public void parseGenesisBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 1, theBitcoinBlock.getTransactions().size(),"Genesis Block must contain exactly one transaction");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Genesis Block must contain exactly one transaction with one input");
-		assertEquals( 77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Genesis Block must contain exactly one transaction with one input and script length 77");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Genesis Block must contain exactly one transaction with one output");
-		assertEquals( 67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Genesis Block must contain exactly one transaction with one output and script length 67");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-
-  @Test
-  public void parseTestNet3GenesisBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3genesis.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 1, theBitcoinBlock.getTransactions().size(),"TestNet3 Genesis Block must contain exactly one transaction");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"TestNet3 Genesis Block must contain exactly one transaction with one input");
-		assertEquals( 77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"TestNet3 Genesis Block must contain exactly one transaction with one input and script length 77");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"TestNet3 Genesis Block must contain exactly one transaction with one output");
-		assertEquals( 67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"TestNet3 Genesis Block must contain exactly one transaction with one output and script length 67");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-
-  @Test
-  public void parseVersion1BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-    ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version1.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 2, theBitcoinBlock.getTransactions().size(),"Random Version 1 Block must contain exactly two transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 1 Block must contain exactly two transactions of which the first has one input");
-		assertEquals( 8, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 1 Block must contain exactly two transactions of which the first has one input and script length 8");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 1 Block must contain exactly two transactions of which the first has one output");
-		assertEquals( 67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 1 Block must contain exactly two transactions of which the first has one output and script length 67");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion2BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-      	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version2.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 343, theBitcoinBlock.getTransactions().size(),"Random Version 2 Block must contain exactly 343 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
-		assertEquals( 40, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 2 Block must contain exactly 343 transactions of which the first has one input and script length 40");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 2 Block must contain exactly 343 transactions of which the first has one output");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 2 Block must contain exactly 343 transactions of which the first has one output and script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion3BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-            ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version3.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 1645, theBitcoinBlock.getTransactions().size(),"Random Version 3 Block must contain exactly 1645 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
-		assertEquals( 49, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 3 Block must contain exactly 1645 transactions of which the first has one input and script length 49");
-		assertEquals( 2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 3 Block must contain exactly 1645 transactions of which the first has two outputs");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 3 Block must contain exactly 1645 transactions of which the first has two output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
-  @Test
-  public void parseVersion4BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+    @Test
+    public void checkTestDataVersion1BlockAvailable() {
         ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="version4.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 936, theBitcoinBlock.getTransactions().size(),"Random Version 4 Block must contain exactly 936 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
-		assertEquals( 4, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random Version 4 Block must contain exactly 936 transactions of which the first has one input and script length 4");
-		assertEquals( 2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random Version 4 Block must contain exactly 936 transactions of which the first has two outputs");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random Version 4 Block must contain exactly 936 transactions of which the first has two output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
+        String fileName = "version1.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    @Test
+    public void checkTestDataVersion2BlockAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version2.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
 
 
-  @Test
-  public void parseTestNet3Version4BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-            ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="testnet3version4.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.TESTNET3_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 3299, theBitcoinBlock.getTransactions().size(),"Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
-		assertEquals( 35, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input and script length 35");
-		assertEquals( 1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one outputs");
-		assertEquals( 25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
+    @Test
+    public void checkTestDataVersion3BlockAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version3.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
 
-@Test
-  public void parseMultiNetBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="multinet.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.MULTINET_MAGIC,direct);
-		BitcoinBlock firstBitcoinBlock = bbr.readBlock();
-		assertEquals( 1, firstBitcoinBlock.getTransactions().size(),"First MultiNet Block must contain exactly one transaction");
-		assertEquals( 1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"First MultiNet Block must contain exactly one transaction with one input");
-		assertEquals( 77, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"First MultiNet Block must contain exactly one transaction with one input and script length 77");
-		assertEquals( 1, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"First MultiNet Block must contain exactly one transaction with one output");
-		assertEquals( 67, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"First MultiNet Block must contain exactly one transaction with one output and script length 67");
-		BitcoinBlock secondBitcoinBlock = bbr.readBlock();
-		assertEquals( 343, secondBitcoinBlock.getTransactions().size(),"Second MultiNet Block must contain exactly 343 transactions");
-		assertEquals( 1, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Second MultiNet Block must contain exactly 343 transactions of which the first has one input");
-		assertEquals( 40, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Second MultiNet Block must contain exactly 343 transactions of which the first has one input and script length 40");
-		assertEquals( 1, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Second MultiNet Block must contain exactly 343 transactions of which the first has one output");
-		assertEquals( 25, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Second MultiNet Block must contain exactly 343 transactions of which the first has one output and script length 25");
-		BitcoinBlock thirdBitcoinBlock = bbr.readBlock();
-		assertEquals( 3299, thirdBitcoinBlock.getTransactions().size(),"Third MultiNet Block must contain exactly 3299 transactions");
-		assertEquals( 1, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().size(),"Third MultiNet Block must contain exactly 3299 transactions of which the first has one input");
-		assertEquals( 35, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length,"Third MultiNet Block must contain exactly 3299 transactions of which the first has one input and script length 35");
-		assertEquals( 1, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(),"Third MultiNet Block must contain exactly 3299 transactions of which the first has one outputs");
-		assertEquals( 25, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length,"Third MultiNet Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
+    @Test
+    public void checkTestDataVersion4BlockAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version4.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    @Test
+    public void checkTestDataVersion1SeekBlockAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "reqseekversion1.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    @Test
+    public void checkTestDataTestnet3GenesisBlockAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
 
 
-@Test
-public void parseScriptWitnessBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 470, theBitcoinBlock.getTransactions().size(),"Random ScriptWitness Block must contain exactly 470 transactions");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
+    @Test
+    public void checkTestDataTestnet3Version4BlockAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3version4.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+
+    @Test
+    public void checkTestDataMultiNetAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "multinet.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    @Test
+    public void checkTestDataScriptWitnessNetAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    @Test
+    public void checkTestDataScriptWitness2NetAvailable() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness2.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
+        File file = new File(fileNameGenesis);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+
+    @Test
+    public void parseGenesisBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertFalse(genesisByteBuffer.isDirect(), "Raw Genesis Block is HeapByteBuffer");
+            assertEquals(293, genesisByteBuffer.limit(), "Raw Genesis block has a size of 293 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion1BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version1.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version1ByteBuffer = bbr.readRawBlock();
+            assertFalse(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block is HeapByteBuffer");
+            assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block has a size of 482 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion2BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version2.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version2ByteBuffer = bbr.readRawBlock();
+            assertFalse(version2ByteBuffer.isDirect(), "Random Version 2 Raw Block is HeapByteBuffer");
+            assertEquals(191198, version2ByteBuffer.limit(), "Random Version 2 Raw Block has a size of 191.198 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseVersion3BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version3.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version3ByteBuffer = bbr.readRawBlock();
+            assertFalse(version3ByteBuffer.isDirect(), "Random Version 3 Raw Block is HeapByteBuffer");
+            assertEquals(932199, version3ByteBuffer.limit(), "Random Version 3 Raw Block has a size of 932.199 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion4BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version4.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version4ByteBuffer = bbr.readRawBlock();
+            assertFalse(version4ByteBuffer.isDirect(), "Random Version 4 Raw Block is HeapByteBuffer");
+            assertEquals(998039, version4ByteBuffer.limit(), "Random Version 4 Raw Block has a size of 998.039 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseTestNet3GenesisBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertFalse(genesisByteBuffer.isDirect(), "Raw TestNet3 Genesis Block is HeapByteBuffer");
+            assertEquals(293, genesisByteBuffer.limit(), "Raw TestNet3 Genesis block has a size of 293 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseTestNet3Version4BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3version4.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            ByteBuffer version4ByteBuffer = bbr.readRawBlock();
+            assertFalse(version4ByteBuffer.isDirect(), "Random TestNet3 Version 4 Raw Block is HeapByteBuffer");
+            assertEquals(749041, version4ByteBuffer.limit(), "Random TestNet3 Version 4 Raw Block has a size of 749.041 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseMultiNetAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "multinet.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
+            assertFalse(firstMultinetByteBuffer.isDirect(), "First MultiNetBlock is HeapByteBuffer");
+            assertEquals(293, firstMultinetByteBuffer.limit(), "First MultiNetBlock has a size of 293 bytes");
+            ByteBuffer secondMultinetByteBuffer = bbr.readRawBlock();
+            assertFalse(secondMultinetByteBuffer.isDirect(), "Second MultiNetBlock is HeapByteBuffer");
+            assertEquals(191198, secondMultinetByteBuffer.limit(), "Second MultiNetBlock has a size of 191.198 bytes");
+            ByteBuffer thirdMultinetByteBuffer = bbr.readRawBlock();
+            assertFalse(thirdMultinetByteBuffer.isDirect(), "Third MultiNetBlock is HeapByteBuffer");
+            assertEquals(749041, thirdMultinetByteBuffer.limit(), "Third MultiNetBlock has a size of 749.041 bytes");
+
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseScriptWitnessBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
+            assertFalse(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is HeapByteBuffer");
+            assertEquals(999283, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999283 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseScriptWitness2BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness2.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
+            assertFalse(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is HeapByteBuffer");
+            assertEquals(1000039, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 1000039 bytes");
+            scriptwitnessByteBuffer = bbr.readRawBlock();
+            assertFalse(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is HeapByteBuffer");
+            assertEquals(999312, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999312 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseGenesisBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertTrue(genesisByteBuffer.isDirect(), "Raw Genesis Block is DirectByteBuffer");
+            assertEquals(293, genesisByteBuffer.limit(), "Raw Genesis Block has a size of 293 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseGenesisBlockTestTime() throws IOException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertTrue(genesisByteBuffer.isDirect(), "Raw Genesis Block is DirectByteBuffer");
+            assertEquals(293, genesisByteBuffer.limit(), "Raw Genesis Block has a size of 293 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion1BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version1.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version1ByteBuffer = bbr.readRawBlock();
+            assertTrue(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block is DirectByteBuffer");
+            assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block has a size of 482 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion2BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version2.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version2ByteBuffer = bbr.readRawBlock();
+            assertTrue(version2ByteBuffer.isDirect(), "Random Version 2 Raw Block is DirectByteBuffer");
+            assertEquals(191198, version2ByteBuffer.limit(), "Random Version 2 Raw Block has a size of 191.198 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion3BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version3.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version3ByteBuffer = bbr.readRawBlock();
+            assertTrue(version3ByteBuffer.isDirect(), "Random Version 3 Raw Block is DirectByteBuffer");
+            assertEquals(932199, version3ByteBuffer.limit(), "Random Version 3 Raw Block has a size of 932.199 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion4BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version4.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer version4ByteBuffer = bbr.readRawBlock();
+            assertTrue(version4ByteBuffer.isDirect(), "Random Version 4 Raw Block is DirectByteBuffer");
+            assertEquals(998039, version4ByteBuffer.limit(), "Random Version 4 Raw Block has a size of 998.039 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseTestNet3GenesisBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertTrue(genesisByteBuffer.isDirect(), "Raw TestNet3 Genesis Block is DirectByteBuffer");
+            assertEquals(293, genesisByteBuffer.limit(), "Raw TestNet3 Genesis block has a size of 293 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseTestNet3Version4BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3version4.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            ByteBuffer version4ByteBuffer = bbr.readRawBlock();
+            assertTrue(version4ByteBuffer.isDirect(), "Random TestNet3 Version 4 Raw Block is DirectByteBuffer");
+            assertEquals(749041, version4ByteBuffer.limit(), "Random TestNet3  Version 4 Raw Block has a size of 749.041 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseMultiNetAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "multinet.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
+            assertTrue(firstMultinetByteBuffer.isDirect(), "First MultiNetBlock is DirectByteBuffer");
+            assertEquals(293, firstMultinetByteBuffer.limit(), "First MultiNetBlock has a size of 293 bytes");
+            ByteBuffer secondMultinetByteBuffer = bbr.readRawBlock();
+            assertTrue(secondMultinetByteBuffer.isDirect(), "Second MultiNetBlock is DirectByteBuffer");
+            assertEquals(191198, secondMultinetByteBuffer.limit(), "Second MultiNetBlock has a size of 191.198 bytes");
+            ByteBuffer thirdMultinetByteBuffer = bbr.readRawBlock();
+            assertTrue(thirdMultinetByteBuffer.isDirect(), "Third MultiNetBlock is DirectByteBuffer");
+            assertEquals(749041, thirdMultinetByteBuffer.limit(), "Third MultiNetBlock has a size of 749.041 bytes");
+
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseScriptWitnessBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
+            assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
+            assertEquals(999283, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999283 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseScriptWitness2BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness2.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
+            assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
+            assertEquals(1000039, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 1000039 bytes");
+            scriptwitnessByteBuffer = bbr.readRawBlock();
+            assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
+            assertEquals(999312, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999312 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseGenesisBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(1, theBitcoinBlock.getTransactions().size(), "Genesis Block must contain exactly one transaction");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Genesis Block must contain exactly one transaction with one input");
+            assertEquals(77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Genesis Block must contain exactly one transaction with one input and script length 77");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Genesis Block must contain exactly one transaction with one output");
+            assertEquals(BigInteger.valueOf(5000000000L), theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getValue(), "Value must be BigInteger corresponding to 5000000000L");
+            assertEquals(67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Genesis Block must contain exactly one transaction with one output and script length 67");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseTestNet3GenesisBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3genesis.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(1, theBitcoinBlock.getTransactions().size(), "TestNet3 Genesis Block must contain exactly one transaction");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one input");
+            assertEquals(77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "TestNet3 Genesis Block must contain exactly one transaction with one input and script length 77");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one output");
+            assertEquals(67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "TestNet3 Genesis Block must contain exactly one transaction with one output and script length 67");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion1BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version1.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(2, theBitcoinBlock.getTransactions().size(), "Random Version 1 Block must contain exactly two transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one input");
+            assertEquals(8, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 1 Block must contain exactly two transactions of which the first has one input and script length 8");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one output");
+            assertEquals(67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 1 Block must contain exactly two transactions of which the first has one output and script length 67");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion2BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version2.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(343, theBitcoinBlock.getTransactions().size(), "Random Version 2 Block must contain exactly 343 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
+            assertEquals(40, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 2 Block must contain exactly 343 transactions of which the first has one input and script length 40");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one output");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 2 Block must contain exactly 343 transactions of which the first has one output and script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion3BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version3.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(1645, theBitcoinBlock.getTransactions().size(), "Random Version 3 Block must contain exactly 1645 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
+            assertEquals(49, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input and script length 49");
+            assertEquals(2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has two outputs");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 3 Block must contain exactly 1645 transactions of which the first has two output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion4BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version4.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(936, theBitcoinBlock.getTransactions().size(), "Random Version 4 Block must contain exactly 936 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
+            assertEquals(4, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 4 Block must contain exactly 936 transactions of which the first has one input and script length 4");
+            assertEquals(2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has two outputs");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 4 Block must contain exactly 936 transactions of which the first has two output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseTestNet3Version4BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3version4.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(3299, theBitcoinBlock.getTransactions().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
+            assertEquals(35, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input and script length 35");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one outputs");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseMultiNetBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "multinet.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            BitcoinBlock firstBitcoinBlock = bbr.readBlock();
+            assertEquals(1, firstBitcoinBlock.getTransactions().size(), "First MultiNet Block must contain exactly one transaction");
+            assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "First MultiNet Block must contain exactly one transaction with one input");
+            assertEquals(77, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "First MultiNet Block must contain exactly one transaction with one input and script length 77");
+            assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "First MultiNet Block must contain exactly one transaction with one output");
+            assertEquals(67, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "First MultiNet Block must contain exactly one transaction with one output and script length 67");
+            BitcoinBlock secondBitcoinBlock = bbr.readBlock();
+            assertEquals(343, secondBitcoinBlock.getTransactions().size(), "Second MultiNet Block must contain exactly 343 transactions");
+            assertEquals(1, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Second MultiNet Block must contain exactly 343 transactions of which the first has one input");
+            assertEquals(40, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Second MultiNet Block must contain exactly 343 transactions of which the first has one input and script length 40");
+            assertEquals(1, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Second MultiNet Block must contain exactly 343 transactions of which the first has one output");
+            assertEquals(25, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Second MultiNet Block must contain exactly 343 transactions of which the first has one output and script length 25");
+            BitcoinBlock thirdBitcoinBlock = bbr.readBlock();
+            assertEquals(3299, thirdBitcoinBlock.getTransactions().size(), "Third MultiNet Block must contain exactly 3299 transactions");
+            assertEquals(1, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Third MultiNet Block must contain exactly 3299 transactions of which the first has one input");
+            assertEquals(35, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Third MultiNet Block must contain exactly 3299 transactions of which the first has one input and script length 35");
+            assertEquals(1, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Third MultiNet Block must contain exactly 3299 transactions of which the first has one outputs");
+            assertEquals(25, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Third MultiNet Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseScriptWitnessBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(470, theBitcoinBlock.getTransactions().size(), "Random ScriptWitness Block must contain exactly 470 transactions");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseScriptWitness2BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness2.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(2191, theBitcoinBlock.getTransactions().size(), "First random ScriptWitness Block must contain exactly 2191 transactions");
+            theBitcoinBlock = bbr.readBlock();
+            assertEquals(2508, theBitcoinBlock.getTransactions().size(), "Second random ScriptWitness Block must contain exactly 2508 transactions");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseGenesisBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(1, theBitcoinBlock.getTransactions().size(), "Genesis Block must contain exactly one transaction");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Genesis Block must contain exactly one transaction with one input");
+            assertEquals(77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Genesis Block must contain exactly one transaction with one input and script length 77");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Genesis Block must contain exactly one transaction with one output");
+            assertEquals(67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Genesis Block must contain exactly one transaction with one output and script length 67");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseTestNet3GenesisBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3genesis.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(1, theBitcoinBlock.getTransactions().size(), "TestNet3 Genesis Block must contain exactly one transaction");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one input");
+            assertEquals(77, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "TestNet3 Genesis Block must contain exactly one transaction with one input and script length 77");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one output");
+            assertEquals(67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "TestNet3 Genesis Block must contain exactly one transaction with one output and script length 67");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseVersion1BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version1.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(2, theBitcoinBlock.getTransactions().size(), "Random Version 1 Block must contain exactly two transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one input");
+            assertEquals(8, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 1 Block must contain exactly two transactions of which the first has one input and script length 8");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one output");
+            assertEquals(67, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 1 Block must contain exactly two transactions of which the first has one output and script length 67");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion2BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version2.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(343, theBitcoinBlock.getTransactions().size(), "Random Version 2 Block must contain exactly 343 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
+            assertEquals(40, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 2 Block must contain exactly 343 transactions of which the first has one input and script length 40");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one output");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 2 Block must contain exactly 343 transactions of which the first has one output and script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion3BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version3.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(1645, theBitcoinBlock.getTransactions().size(), "Random Version 3 Block must contain exactly 1645 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
+            assertEquals(49, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input and script length 49");
+            assertEquals(2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has two outputs");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 3 Block must contain exactly 1645 transactions of which the first has two output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseVersion4BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "version4.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(936, theBitcoinBlock.getTransactions().size(), "Random Version 4 Block must contain exactly 936 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
+            assertEquals(4, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random Version 4 Block must contain exactly 936 transactions of which the first has one input and script length 4");
+            assertEquals(2, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has two outputs");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random Version 4 Block must contain exactly 936 transactions of which the first has two output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseTestNet3Version4BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "testnet3version4.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(3299, theBitcoinBlock.getTransactions().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
+            assertEquals(35, theBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input and script length 35");
+            assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one outputs");
+            assertEquals(25, theBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseMultiNetBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "multinet.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            BitcoinBlock firstBitcoinBlock = bbr.readBlock();
+            assertEquals(1, firstBitcoinBlock.getTransactions().size(), "First MultiNet Block must contain exactly one transaction");
+            assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "First MultiNet Block must contain exactly one transaction with one input");
+            assertEquals(77, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "First MultiNet Block must contain exactly one transaction with one input and script length 77");
+            assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "First MultiNet Block must contain exactly one transaction with one output");
+            assertEquals(67, firstBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "First MultiNet Block must contain exactly one transaction with one output and script length 67");
+            BitcoinBlock secondBitcoinBlock = bbr.readBlock();
+            assertEquals(343, secondBitcoinBlock.getTransactions().size(), "Second MultiNet Block must contain exactly 343 transactions");
+            assertEquals(1, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Second MultiNet Block must contain exactly 343 transactions of which the first has one input");
+            assertEquals(40, secondBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Second MultiNet Block must contain exactly 343 transactions of which the first has one input and script length 40");
+            assertEquals(1, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Second MultiNet Block must contain exactly 343 transactions of which the first has one output");
+            assertEquals(25, secondBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Second MultiNet Block must contain exactly 343 transactions of which the first has one output and script length 25");
+            BitcoinBlock thirdBitcoinBlock = bbr.readBlock();
+            assertEquals(3299, thirdBitcoinBlock.getTransactions().size(), "Third MultiNet Block must contain exactly 3299 transactions");
+            assertEquals(1, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Third MultiNet Block must contain exactly 3299 transactions of which the first has one input");
+            assertEquals(35, thirdBitcoinBlock.getTransactions().get(0).getListOfInputs().get(0).getTxInScript().length, "Third MultiNet Block must contain exactly 3299 transactions of which the first has one input and script length 35");
+            assertEquals(1, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().size(), "Third MultiNet Block must contain exactly 3299 transactions of which the first has one outputs");
+            assertEquals(25, thirdBitcoinBlock.getTransactions().get(0).getListOfOutputs().get(0).getTxOutScript().length, "Third MultiNet Block must contain exactly 3299 transactions of which the first has one output and the first output script length 25");
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
+    @Test
+    public void parseScriptWitnessBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(470, theBitcoinBlock.getTransactions().size(), "Random ScriptWitness Block must contain exactly 470 transactions");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void parseScriptWitness2BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "scriptwitness2.blk";
+        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fullFileNameString);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            BitcoinBlock theBitcoinBlock = bbr.readBlock();
+            assertEquals(2191, theBitcoinBlock.getTransactions().size(), "First random ScriptWitness Block must contain exactly 2191 transactions");
+            theBitcoinBlock = bbr.readBlock();
+            assertEquals(2508, theBitcoinBlock.getTransactions().size(), "Second random ScriptWitness Block must contain exactly 2508 transactions");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void seekBlockStartHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "reqseekversion1.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr.seekBlockStart();
+            ByteBuffer version1ByteBuffer = bbr.readRawBlock();
+            assertFalse(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block (requiring seek) is HeapByteBuffer");
+            assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block (requiring seek) has a size of 482 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void seekBlockStartDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "reqseekversion1.blk";
+        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameBlock);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr.seekBlockStart();
+            ByteBuffer version1ByteBuffer = bbr.readRawBlock();
+            assertTrue(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block (requiring seek) is DirectByteBuffer");
+            assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block (requiring seek) has a size of 482 bytes");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void getKeyFromRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = false;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertFalse(genesisByteBuffer.isDirect(), "Raw Genesis Block is HeapByteBuffer");
+            byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
+            assertEquals(64, key.length, "Raw Genesis Block Key should have a size of 64 bytes");
+            byte[] comparatorKey = new byte[]{(byte) 0x3B, (byte) 0xA3, (byte) 0xED, (byte) 0xFD, (byte) 0x7A, (byte) 0x7B, (byte) 0x12, (byte) 0xB2, (byte) 0x7A, (byte) 0xC7, (byte) 0x2C, (byte) 0x3E, (byte) 0x67, (byte) 0x76, (byte) 0x8F, (byte) 0x61, (byte) 0x7F, (byte) 0xC8, (byte) 0x1B, (byte) 0xC3, (byte) 0x88, (byte) 0x8A, (byte) 0x51, (byte) 0x32, (byte) 0x3A, (byte) 0x9F, (byte) 0xB8, (byte) 0xAA, (byte) 0x4B, (byte) 0x1E, (byte) 0x5E, (byte) 0x4A, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00};
+            assertArrayEquals(comparatorKey, key, "Raw Genesis Block Key is equivalent to comparator key");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+    @Test
+    public void getKeyFromRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
+        ClassLoader classLoader = getClass().getClassLoader();
+        String fileName = "genesis.blk";
+        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
+        File file = new File(fileNameGenesis);
+        BitcoinBlockReader bbr = null;
+        boolean direct = true;
+        try {
+            FileInputStream fin = new FileInputStream(file);
+            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            ByteBuffer genesisByteBuffer = bbr.readRawBlock();
+            assertTrue(genesisByteBuffer.isDirect(), "Raw Genesis Block is DirectByteBuffer");
+            byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
+            assertEquals(64, key.length, "Raw Genesis Block Key should have a size of 64 bytes");
+            byte[] comparatorKey = new byte[]{(byte) 0x3B, (byte) 0xA3, (byte) 0xED, (byte) 0xFD, (byte) 0x7A, (byte) 0x7B, (byte) 0x12, (byte) 0xB2, (byte) 0x7A, (byte) 0xC7, (byte) 0x2C, (byte) 0x3E, (byte) 0x67, (byte) 0x76, (byte) 0x8F, (byte) 0x61, (byte) 0x7F, (byte) 0xC8, (byte) 0x1B, (byte) 0xC3, (byte) 0x88, (byte) 0x8A, (byte) 0x51, (byte) 0x32, (byte) 0x3A, (byte) 0x9F, (byte) 0xB8, (byte) 0xAA, (byte) 0x4B, (byte) 0x1E, (byte) 0x5E, (byte) 0x4A, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00};
+            assertArrayEquals(comparatorKey, key, "Raw Genesis Block Key is equivalent to comparator key");
+
+        } finally {
+            if (bbr != null)
+                bbr.close();
+        }
+    }
+
+
 }
-
-@Test
-public void parseScriptWitness2BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="scriptwitness2.blk";
-	String fullFileNameString=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fullFileNameString);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		BitcoinBlock theBitcoinBlock = bbr.readBlock();
-		assertEquals( 2191, theBitcoinBlock.getTransactions().size(),"First random ScriptWitness Block must contain exactly 2191 transactions");
-		theBitcoinBlock = bbr.readBlock();
-		assertEquals( 2508, theBitcoinBlock.getTransactions().size(),"Second random ScriptWitness Block must contain exactly 2508 transactions");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-}
-
-  @Test
-  public void seekBlockStartHeap()  throws FileNotFoundException, IOException, BitcoinBlockReadException {
-     ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="reqseekversion1.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		bbr.seekBlockStart();
-		ByteBuffer version1ByteBuffer = bbr.readRawBlock();
-		assertFalse( version1ByteBuffer.isDirect(),"Random Version 1 Raw Block (requiring seek) is HeapByteBuffer");
-		assertEquals( 482, version1ByteBuffer.limit(),"Random Version 1 Raw Block (requiring seek) has a size of 482 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
- @Test
-  public void seekBlockStartDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException  {
-         ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="reqseekversion1.blk";
-	String fileNameBlock=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameBlock);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		bbr.seekBlockStart();
-		ByteBuffer version1ByteBuffer = bbr.readRawBlock();
-		assertTrue( version1ByteBuffer.isDirect(),"Random Version 1 Raw Block (requiring seek) is DirectByteBuffer");
-		assertEquals( 482, version1ByteBuffer.limit(),"Random Version 1 Raw Block (requiring seek) has a size of 482 bytes");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
- @Test
-  public void getKeyFromRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=false;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer genesisByteBuffer = bbr.readRawBlock();
-		assertFalse( genesisByteBuffer.isDirect(),"Raw Genesis Block is HeapByteBuffer");
-		byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
-		assertEquals( 64, key.length,"Raw Genesis Block Key should have a size of 64 bytes");
-		byte[] comparatorKey = new byte[]{(byte)0x3B,(byte)0xA3,(byte)0xED,(byte)0xFD,(byte)0x7A,(byte)0x7B,(byte)0x12,(byte)0xB2,(byte)0x7A,(byte)0xC7,(byte)0x2C,(byte)0x3E,(byte)0x67,(byte)0x76,(byte)0x8F,(byte)0x61,(byte)0x7F,(byte)0xC8,(byte)0x1B,(byte)0xC3,(byte)0x88,(byte)0x8A,(byte)0x51,(byte)0x32,(byte)0x3A,(byte)0x9F,(byte)0xB8,(byte)0xAA,(byte)0x4B,(byte)0x1E,(byte)0x5E,(byte)0x4A,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00};
-		assertArrayEquals( comparatorKey, key,"Raw Genesis Block Key is equivalent to comparator key");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-  }
-
- @Test
-  public void getKeyFromRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-	ClassLoader classLoader = getClass().getClassLoader();
-	String fileName="genesis.blk";
-	String fileNameGenesis=classLoader.getResource("testdata/"+fileName).getFile();	
-	File file = new File(fileNameGenesis);
-	BitcoinBlockReader bbr = null;
-	boolean direct=true;
-	try {
-		FileInputStream fin = new FileInputStream(file);
-		bbr = new BitcoinBlockReader(fin,this.DEFAULT_MAXSIZE_BITCOINBLOCK,this.DEFAULT_BUFFERSIZE,this.DEFAULT_MAGIC,direct);
-		ByteBuffer genesisByteBuffer = bbr.readRawBlock();
-		assertTrue( genesisByteBuffer.isDirect(),"Raw Genesis Block is DirectByteBuffer");
-		byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
-		assertEquals( 64, key.length,"Raw Genesis Block Key should have a size of 64 bytes");
-		byte[] comparatorKey = new byte[]{(byte)0x3B,(byte)0xA3,(byte)0xED,(byte)0xFD,(byte)0x7A,(byte)0x7B,(byte)0x12,(byte)0xB2,(byte)0x7A,(byte)0xC7,(byte)0x2C,(byte)0x3E,(byte)0x67,(byte)0x76,(byte)0x8F,(byte)0x61,(byte)0x7F,(byte)0xC8,(byte)0x1B,(byte)0xC3,(byte)0x88,(byte)0x8A,(byte)0x51,(byte)0x32,(byte)0x3A,(byte)0x9F,(byte)0xB8,(byte)0xAA,(byte)0x4B,(byte)0x1E,(byte)0x5E,(byte)0x4A,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00,(byte)0x00};
-		assertArrayEquals( comparatorKey, key,"Raw Genesis Block Key is equivalent to comparator key");
-		
-	} finally {
-		if (bbr!=null) 
-			bbr.close();
-	}
-	}
-
-
-
-} 
 
 

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
@@ -1,18 +1,18 @@
-/**
-* Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-**/
+/*
+ Copyright 2016 ZuInnoTe (Jörn Franke) <zuinnote@gmail.com>
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
 
 package org.zuinnote.hadoop.bitcoin.format.common;
 
@@ -31,7 +31,6 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 
 import org.junit.jupiter.api.Test;
-import org.zuinnote.hadoop.bitcoin.format.common.BitcoinBlockReader;
 import org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException;
 
 

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/BitcoinFormatReaderTest.java
@@ -16,27 +16,26 @@
 
 package org.zuinnote.hadoop.bitcoin.format.common;
 
-
 import org.junit.jupiter.api.Test;
 import org.zuinnote.hadoop.bitcoin.format.exception.BitcoinBlockReadException;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 
 public class BitcoinFormatReaderTest {
+
     static final int DEFAULT_BUFFERSIZE = 64 * 1024;
     static final int DEFAULT_MAXSIZE_BITCOINBLOCK = 8 * 1024 * 1024;
     static final byte[][] DEFAULT_MAGIC = {{(byte) 0xF9, (byte) 0xBE, (byte) 0xB4, (byte) 0xD9}};
@@ -44,146 +43,24 @@ public class BitcoinFormatReaderTest {
     private static final byte[][] MULTINET_MAGIC = {{(byte) 0xF9, (byte) 0xBE, (byte) 0xB4, (byte) 0xD9}, {(byte) 0x0B, (byte) 0x11, (byte) 0x09, (byte) 0x07}};
 
     @Test
-    public void checkTestDataGenesisBlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-
-    @Test
-    public void checkTestDataVersion1BlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version1.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    public void checkTestDataAvailable() {
+        String[] testFiles = new String[] {
+                "genesis.blk", "version1.blk", "version2.blk", "version3.blk", "version4.blk",
+                "reqseekversion1.blk", "testnet3genesis.blk", "testnet3version4.blk", "testnet3version4.blk",
+                "multinet.blk", "scriptwitness.blk", "scriptwitness2.blk"};
+        for(String fileName: testFiles) {
+            testAvailable(fileName);
+        }
     }
 
     @Test
-    public void checkTestDataVersion2BlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version2.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-
-    @Test
-    public void checkTestDataVersion3BlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version3.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-    @Test
-    public void checkTestDataVersion4BlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version4.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-    @Test
-    public void checkTestDataVersion1SeekBlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "reqseekversion1.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-    @Test
-    public void checkTestDataTestnet3GenesisBlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-
-    @Test
-    public void checkTestDataTestnet3Version4BlockAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3version4.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-
-    @Test
-    public void checkTestDataMultiNetAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "multinet.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-    @Test
-    public void checkTestDataScriptWitnessNetAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-    @Test
-    public void checkTestDataScriptWitness2NetAvailable() {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness2.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        assertNotNull(fileNameGenesis, "Test Data File \"" + fileName + "\" is not null in resource path");
-        File file = new File(fileNameGenesis);
-        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
-        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
-    }
-
-
-    @Test
-    public void parseGenesisBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void parseGenesisBlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("genesis.blk", false);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertFalse(genesisByteBuffer.isDirect(), "Raw Genesis Block is HeapByteBuffer");
             assertEquals(293, genesisByteBuffer.limit(), "Raw Genesis block has a size of 293 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -191,20 +68,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion1BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version1.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion1BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version1.blk", false);
             ByteBuffer version1ByteBuffer = bbr.readRawBlock();
             assertFalse(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block is HeapByteBuffer");
             assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block has a size of 482 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -212,42 +82,27 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion2BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version2.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion2BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version2.blk", false);
             ByteBuffer version2ByteBuffer = bbr.readRawBlock();
             assertFalse(version2ByteBuffer.isDirect(), "Random Version 2 Raw Block is HeapByteBuffer");
             assertEquals(191198, version2ByteBuffer.limit(), "Random Version 2 Raw Block has a size of 191.198 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
         }
     }
 
-
     @Test
-    public void parseVersion3BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version3.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion3BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version3.blk", false);
             ByteBuffer version3ByteBuffer = bbr.readRawBlock();
             assertFalse(version3ByteBuffer.isDirect(), "Random Version 3 Raw Block is HeapByteBuffer");
             assertEquals(932199, version3ByteBuffer.limit(), "Random Version 3 Raw Block has a size of 932.199 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -255,20 +110,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion4BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version4.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion4BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version4.blk", false);
             ByteBuffer version4ByteBuffer = bbr.readRawBlock();
             assertFalse(version4ByteBuffer.isDirect(), "Random Version 4 Raw Block is HeapByteBuffer");
             assertEquals(998039, version4ByteBuffer.limit(), "Random Version 4 Raw Block has a size of 998.039 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -276,20 +124,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseTestNet3GenesisBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void parseTestNet3GenesisBlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3genesis.blk", false, TESTNET3_MAGIC);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertFalse(genesisByteBuffer.isDirect(), "Raw TestNet3 Genesis Block is HeapByteBuffer");
             assertEquals(293, genesisByteBuffer.limit(), "Raw TestNet3 Genesis block has a size of 293 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -297,38 +138,24 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseTestNet3Version4BlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3version4.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseTestNet3Version4BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3version4.blk", false, TESTNET3_MAGIC);
             ByteBuffer version4ByteBuffer = bbr.readRawBlock();
             assertFalse(version4ByteBuffer.isDirect(), "Random TestNet3 Version 4 Raw Block is HeapByteBuffer");
             assertEquals(749041, version4ByteBuffer.limit(), "Random TestNet3 Version 4 Raw Block has a size of 749.041 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
         }
     }
 
-
     @Test
-    public void parseMultiNetAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "multinet.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void parseMultiNetAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            bbr = blockReader("multinet.blk", false, MULTINET_MAGIC);
             ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
             assertFalse(firstMultinetByteBuffer.isDirect(), "First MultiNetBlock is HeapByteBuffer");
             assertEquals(293, firstMultinetByteBuffer.limit(), "First MultiNetBlock has a size of 293 bytes");
@@ -338,8 +165,6 @@ public class BitcoinFormatReaderTest {
             ByteBuffer thirdMultinetByteBuffer = bbr.readRawBlock();
             assertFalse(thirdMultinetByteBuffer.isDirect(), "Third MultiNetBlock is HeapByteBuffer");
             assertEquals(749041, thirdMultinetByteBuffer.limit(), "Third MultiNetBlock has a size of 749.041 bytes");
-
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -347,26 +172,18 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseScriptWitnessBlockAsBitcoinRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseScriptWitnessBlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness.blk", false);
             ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
             assertFalse(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is HeapByteBuffer");
             assertEquals(999283, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999283 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
         }
     }
-
 
     @Test
     public void parseScriptWitness2BlockAsBitcoinRawBlockHeap() throws IOException, BitcoinBlockReadException {
@@ -383,20 +200,6 @@ public class BitcoinFormatReaderTest {
             if (bbr != null)
                 bbr.close();
         }
-    }
-
-    public BitcoinBlockReader blockReader(String fileName, boolean direct) throws IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
-        BitcoinBlockReader bbr = null;
-        FileInputStream fin = new FileInputStream(file);
-        return new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE,
-                                                this.DEFAULT_MAGIC, direct);
-    }
-
-    public BitcoinBlockReader genesisBlockReader(boolean direct) throws IOException, BitcoinBlockReadException {
-        return blockReader("genesis.blk", direct);
     }
 
     @Test
@@ -422,7 +225,7 @@ public class BitcoinFormatReaderTest {
         Calendar x = new GregorianCalendar();
         x.setTime(expected);
         Calendar y = new GregorianCalendar();
-        y.setTime(expected);
+        y.setTime(actual);
         Integer[] fields = new Integer[]
             {Calendar.YEAR, Calendar.MONTH, Calendar.DAY_OF_MONTH, Calendar.HOUR_OF_DAY, Calendar.MINUTE};
         for(int field : fields) {
@@ -448,20 +251,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion1BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version1.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion1BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version1.blk", true);
             ByteBuffer version1ByteBuffer = bbr.readRawBlock();
             assertTrue(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block is DirectByteBuffer");
             assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block has a size of 482 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -469,20 +265,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion2BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version2.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion2BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version2.blk", true);
             ByteBuffer version2ByteBuffer = bbr.readRawBlock();
             assertTrue(version2ByteBuffer.isDirect(), "Random Version 2 Raw Block is DirectByteBuffer");
             assertEquals(191198, version2ByteBuffer.limit(), "Random Version 2 Raw Block has a size of 191.198 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -490,20 +279,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion3BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version3.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion3BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version3.blk", true);
             ByteBuffer version3ByteBuffer = bbr.readRawBlock();
             assertTrue(version3ByteBuffer.isDirect(), "Random Version 3 Raw Block is DirectByteBuffer");
             assertEquals(932199, version3ByteBuffer.limit(), "Random Version 3 Raw Block has a size of 932.199 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -511,20 +293,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion4BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version4.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseVersion4BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version4.blk", true);
             ByteBuffer version4ByteBuffer = bbr.readRawBlock();
             assertTrue(version4ByteBuffer.isDirect(), "Random Version 4 Raw Block is DirectByteBuffer");
             assertEquals(998039, version4ByteBuffer.limit(), "Random Version 4 Raw Block has a size of 998.039 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -532,20 +307,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseTestNet3GenesisBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void parseTestNet3GenesisBlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3genesis.blk", true, TESTNET3_MAGIC);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertTrue(genesisByteBuffer.isDirect(), "Raw TestNet3 Genesis Block is DirectByteBuffer");
             assertEquals(293, genesisByteBuffer.limit(), "Raw TestNet3 Genesis block has a size of 293 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -553,20 +321,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseTestNet3Version4BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3version4.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseTestNet3Version4BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3version4.blk", true, TESTNET3_MAGIC);
             ByteBuffer version4ByteBuffer = bbr.readRawBlock();
             assertTrue(version4ByteBuffer.isDirect(), "Random TestNet3 Version 4 Raw Block is DirectByteBuffer");
             assertEquals(749041, version4ByteBuffer.limit(), "Random TestNet3  Version 4 Raw Block has a size of 749.041 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -574,16 +335,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseMultiNetAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "multinet.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void parseMultiNetAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            bbr = blockReader("multinet.blk", true, MULTINET_MAGIC);
             ByteBuffer firstMultinetByteBuffer = bbr.readRawBlock();
             assertTrue(firstMultinetByteBuffer.isDirect(), "First MultiNetBlock is DirectByteBuffer");
             assertEquals(293, firstMultinetByteBuffer.limit(), "First MultiNetBlock has a size of 293 bytes");
@@ -593,8 +348,6 @@ public class BitcoinFormatReaderTest {
             ByteBuffer thirdMultinetByteBuffer = bbr.readRawBlock();
             assertTrue(thirdMultinetByteBuffer.isDirect(), "Third MultiNetBlock is DirectByteBuffer");
             assertEquals(749041, thirdMultinetByteBuffer.limit(), "Third MultiNetBlock has a size of 749.041 bytes");
-
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -602,20 +355,13 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseScriptWitnessBlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseScriptWitnessBlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness.blk", true);
             ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
             assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
             assertEquals(999283, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999283 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -623,41 +369,27 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseScriptWitness2BlockAsBitcoinRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness2.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void parseScriptWitness2BlockAsBitcoinRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness2.blk", true);
             ByteBuffer scriptwitnessByteBuffer = bbr.readRawBlock();
             assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
             assertEquals(1000039, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 1000039 bytes");
             scriptwitnessByteBuffer = bbr.readRawBlock();
             assertTrue(scriptwitnessByteBuffer.isDirect(), "Random ScriptWitness Raw Block is DirectByteBuffer");
             assertEquals(999312, scriptwitnessByteBuffer.limit(), "Random ScriptWitness Raw Block has a size of 999312 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
         }
     }
 
-
     @Test
-    public void parseGenesisBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "genesis.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseGenesisBlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("genesis.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1, theBitcoinBlock.getTransactions().size(), "Genesis Block must contain exactly one transaction");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Genesis Block must contain exactly one transaction with one input");
@@ -671,18 +403,11 @@ public class BitcoinFormatReaderTest {
         }
     }
 
-
     @Test
-    public void parseTestNet3GenesisBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3genesis.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseTestNet3GenesisBlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3genesis.blk", false, TESTNET3_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1, theBitcoinBlock.getTransactions().size(), "TestNet3 Genesis Block must contain exactly one transaction");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one input");
@@ -696,16 +421,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion1BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version1.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion1BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version1.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(2, theBitcoinBlock.getTransactions().size(), "Random Version 1 Block must contain exactly two transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one input");
@@ -719,16 +438,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion2BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version2.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion2BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version2.blk", false, DEFAULT_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(343, theBitcoinBlock.getTransactions().size(), "Random Version 2 Block must contain exactly 343 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
@@ -742,16 +455,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion3BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version3.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion3BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version3.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1645, theBitcoinBlock.getTransactions().size(), "Random Version 3 Block must contain exactly 1645 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
@@ -765,16 +472,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion4BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version4.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion4BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version4.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(936, theBitcoinBlock.getTransactions().size(), "Random Version 4 Block must contain exactly 936 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
@@ -788,16 +489,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseTestNet3Version4BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3version4.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseTestNet3Version4BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3version4.blk", false, TESTNET3_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(3299, theBitcoinBlock.getTransactions().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
@@ -811,16 +506,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseMultiNetBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "multinet.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseMultiNetBlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            bbr = blockReader("multinet.blk", false, MULTINET_MAGIC);
             BitcoinBlock firstBitcoinBlock = bbr.readBlock();
             assertEquals(1, firstBitcoinBlock.getTransactions().size(), "First MultiNet Block must contain exactly one transaction");
             assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "First MultiNet Block must contain exactly one transaction with one input");
@@ -846,42 +535,27 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseScriptWitnessBlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseScriptWitnessBlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(470, theBitcoinBlock.getTransactions().size(), "Random ScriptWitness Block must contain exactly 470 transactions");
-
         } finally {
             if (bbr != null)
                 bbr.close();
         }
     }
 
-
     @Test
-    public void parseScriptWitness2BlockAsBitcoinBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness2.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseScriptWitness2BlockAsBitcoinBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness2.blk", false);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(2191, theBitcoinBlock.getTransactions().size(), "First random ScriptWitness Block must contain exactly 2191 transactions");
             theBitcoinBlock = bbr.readBlock();
             assertEquals(2508, theBitcoinBlock.getTransactions().size(), "Second random ScriptWitness Block must contain exactly 2508 transactions");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -889,16 +563,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseGenesisBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "genesis.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseGenesisBlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("genesis.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1, theBitcoinBlock.getTransactions().size(), "Genesis Block must contain exactly one transaction");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Genesis Block must contain exactly one transaction with one input");
@@ -911,18 +579,11 @@ public class BitcoinFormatReaderTest {
         }
     }
 
-
     @Test
-    public void parseTestNet3GenesisBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3genesis.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseTestNet3GenesisBlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3genesis.blk", true, TESTNET3_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1, theBitcoinBlock.getTransactions().size(), "TestNet3 Genesis Block must contain exactly one transaction");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "TestNet3 Genesis Block must contain exactly one transaction with one input");
@@ -937,16 +598,10 @@ public class BitcoinFormatReaderTest {
 
 
     @Test
-    public void parseVersion1BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version1.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion1BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version1.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(2, theBitcoinBlock.getTransactions().size(), "Random Version 1 Block must contain exactly two transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 1 Block must contain exactly two transactions of which the first has one input");
@@ -960,16 +615,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion2BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version2.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion2BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version2.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(343, theBitcoinBlock.getTransactions().size(), "Random Version 2 Block must contain exactly 343 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 2 Block must contain exactly 343 transactions of which the first has one input");
@@ -983,16 +632,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion3BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version3.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion3BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version3.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(1645, theBitcoinBlock.getTransactions().size(), "Random Version 3 Block must contain exactly 1645 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 3 Block must contain exactly 1645 transactions of which the first has one input");
@@ -1006,16 +649,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseVersion4BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "version4.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseVersion4BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("version4.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(936, theBitcoinBlock.getTransactions().size(), "Random Version 4 Block must contain exactly 936 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random Version 4 Block must contain exactly 936 transactions of which the first has one input");
@@ -1028,18 +665,11 @@ public class BitcoinFormatReaderTest {
         }
     }
 
-
     @Test
-    public void parseTestNet3Version4BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "testnet3version4.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseTestNet3Version4BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.TESTNET3_MAGIC, direct);
+            bbr = blockReader("testnet3version4.blk", true, TESTNET3_MAGIC);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(3299, theBitcoinBlock.getTransactions().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions");
             assertEquals(1, theBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "Random TestNet3 Version 4 Block must contain exactly 3299 transactions of which the first has one input");
@@ -1053,16 +683,10 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseMultiNetBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "multinet.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseMultiNetBlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.MULTINET_MAGIC, direct);
+            bbr = blockReader("multinet.blk", true, MULTINET_MAGIC);
             BitcoinBlock firstBitcoinBlock = bbr.readBlock();
             assertEquals(1, firstBitcoinBlock.getTransactions().size(), "First MultiNet Block must contain exactly one transaction");
             assertEquals(1, firstBitcoinBlock.getTransactions().get(0).getListOfInputs().size(), "First MultiNet Block must contain exactly one transaction with one input");
@@ -1087,21 +711,13 @@ public class BitcoinFormatReaderTest {
         }
     }
 
-
     @Test
-    public void parseScriptWitnessBlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseScriptWitnessBlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(470, theBitcoinBlock.getTransactions().size(), "Random ScriptWitness Block must contain exactly 470 transactions");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -1109,21 +725,14 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void parseScriptWitness2BlockAsBitcoinBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "scriptwitness2.blk";
-        String fullFileNameString = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fullFileNameString);
+    public void parseScriptWitness2BlockAsBitcoinBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("scriptwitness2.blk", true);
             BitcoinBlock theBitcoinBlock = bbr.readBlock();
             assertEquals(2191, theBitcoinBlock.getTransactions().size(), "First random ScriptWitness Block must contain exactly 2191 transactions");
             theBitcoinBlock = bbr.readBlock();
             assertEquals(2508, theBitcoinBlock.getTransactions().size(), "Second random ScriptWitness Block must contain exactly 2508 transactions");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -1131,21 +740,14 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void seekBlockStartHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "reqseekversion1.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void seekBlockStartHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("reqseekversion1.blk", false);
             bbr.seekBlockStart();
             ByteBuffer version1ByteBuffer = bbr.readRawBlock();
             assertFalse(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block (requiring seek) is HeapByteBuffer");
             assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block (requiring seek) has a size of 482 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -1153,21 +755,14 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void seekBlockStartDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "reqseekversion1.blk";
-        String fileNameBlock = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameBlock);
+    public void seekBlockStartDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("reqseekversion1.blk", true);
             bbr.seekBlockStart();
             ByteBuffer version1ByteBuffer = bbr.readRawBlock();
             assertTrue(version1ByteBuffer.isDirect(), "Random Version 1 Raw Block (requiring seek) is DirectByteBuffer");
             assertEquals(482, version1ByteBuffer.limit(), "Random Version 1 Raw Block (requiring seek) has a size of 482 bytes");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -1175,23 +770,16 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void getKeyFromRawBlockHeap() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void getKeyFromRawBlockHeap() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = false;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("genesis.blk", false);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertFalse(genesisByteBuffer.isDirect(), "Raw Genesis Block is HeapByteBuffer");
             byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
             assertEquals(64, key.length, "Raw Genesis Block Key should have a size of 64 bytes");
             byte[] comparatorKey = new byte[]{(byte) 0x3B, (byte) 0xA3, (byte) 0xED, (byte) 0xFD, (byte) 0x7A, (byte) 0x7B, (byte) 0x12, (byte) 0xB2, (byte) 0x7A, (byte) 0xC7, (byte) 0x2C, (byte) 0x3E, (byte) 0x67, (byte) 0x76, (byte) 0x8F, (byte) 0x61, (byte) 0x7F, (byte) 0xC8, (byte) 0x1B, (byte) 0xC3, (byte) 0x88, (byte) 0x8A, (byte) 0x51, (byte) 0x32, (byte) 0x3A, (byte) 0x9F, (byte) 0xB8, (byte) 0xAA, (byte) 0x4B, (byte) 0x1E, (byte) 0x5E, (byte) 0x4A, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00};
             assertArrayEquals(comparatorKey, key, "Raw Genesis Block Key is equivalent to comparator key");
-
         } finally {
             if (bbr != null)
                 bbr.close();
@@ -1199,30 +787,45 @@ public class BitcoinFormatReaderTest {
     }
 
     @Test
-    public void getKeyFromRawBlockDirect() throws FileNotFoundException, IOException, BitcoinBlockReadException {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = "genesis.blk";
-        String fileNameGenesis = classLoader.getResource("testdata/" + fileName).getFile();
-        File file = new File(fileNameGenesis);
+    public void getKeyFromRawBlockDirect() throws IOException, BitcoinBlockReadException {
         BitcoinBlockReader bbr = null;
-        boolean direct = true;
         try {
-            FileInputStream fin = new FileInputStream(file);
-            bbr = new BitcoinBlockReader(fin, this.DEFAULT_MAXSIZE_BITCOINBLOCK, this.DEFAULT_BUFFERSIZE, this.DEFAULT_MAGIC, direct);
+            bbr = blockReader("genesis.blk", true);
             ByteBuffer genesisByteBuffer = bbr.readRawBlock();
             assertTrue(genesisByteBuffer.isDirect(), "Raw Genesis Block is DirectByteBuffer");
             byte[] key = bbr.getKeyFromRawBlock(genesisByteBuffer);
             assertEquals(64, key.length, "Raw Genesis Block Key should have a size of 64 bytes");
             byte[] comparatorKey = new byte[]{(byte) 0x3B, (byte) 0xA3, (byte) 0xED, (byte) 0xFD, (byte) 0x7A, (byte) 0x7B, (byte) 0x12, (byte) 0xB2, (byte) 0x7A, (byte) 0xC7, (byte) 0x2C, (byte) 0x3E, (byte) 0x67, (byte) 0x76, (byte) 0x8F, (byte) 0x61, (byte) 0x7F, (byte) 0xC8, (byte) 0x1B, (byte) 0xC3, (byte) 0x88, (byte) 0x8A, (byte) 0x51, (byte) 0x32, (byte) 0x3A, (byte) 0x9F, (byte) 0xB8, (byte) 0xAA, (byte) 0x4B, (byte) 0x1E, (byte) 0x5E, (byte) 0x4A, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00};
             assertArrayEquals(comparatorKey, key, "Raw Genesis Block Key is equivalent to comparator key");
-
         } finally {
             if (bbr != null)
                 bbr.close();
         }
     }
 
+    public String getFullFilename(String fileName) {
+        return Objects.requireNonNull(getClass().getClassLoader().getResource("testdata/" + fileName)).getFile();
+    }
+
+    public void testAvailable(String fileName) {
+        String fullFilename = getFullFilename(fileName);
+        File file = new File(fullFilename);
+        assertTrue(file.exists(), "Test Data File \"" + fileName + "\" exists");
+        assertFalse(file.isDirectory(), "Test Data File \"" + fileName + "\" is not a directory");
+    }
+
+    public BitcoinBlockReader blockReader(String fileName, boolean direct) throws IOException {
+        return blockReader(fileName, direct, DEFAULT_MAGIC);
+    }
+
+    public BitcoinBlockReader blockReader(String fileName, boolean direct, byte[][] magic) throws IOException {
+        File file = new File(getFullFilename(fileName));
+        FileInputStream fin = new FileInputStream(file);
+        return new BitcoinBlockReader(fin, DEFAULT_MAXSIZE_BITCOINBLOCK, DEFAULT_BUFFERSIZE, magic, direct);
+    }
+
+    public BitcoinBlockReader genesisBlockReader(boolean direct) throws IOException {
+        return blockReader("genesis.blk", direct);
+    }
 
 }
-
-

--- a/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/LittleEndianUInt32Test.java
+++ b/inputformat/src/test/java/org/zuinnote/hadoop/bitcoin/format/common/LittleEndianUInt32Test.java
@@ -1,0 +1,47 @@
+package org.zuinnote.hadoop.bitcoin.format.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LittleEndianUInt32Test {
+
+    @Test
+    public void testZero() {
+        byte[] zeroBytes = { 0x00, 0x00, 0x00, 0x00 };
+        LittleEndianUInt32 zero = new LittleEndianUInt32(zeroBytes);
+        assertEquals(0L, zero.getValue());
+    }
+
+    @Test
+    public void testOne() {
+        byte[] oneBytes = { 0x01, 0x00, 0x00, 0x00 };
+        LittleEndianUInt32 one = new LittleEndianUInt32(oneBytes);
+        assertEquals(1L, one.getValue());
+    }
+
+    @Test
+    public void testMaxUInt() {
+        int[] allOnes = { 0xff, 0xff, 0xff, 0xff };
+        LittleEndianUInt32 maxUInt = new LittleEndianUInt32(asByte(allOnes));
+        assertEquals(4294967295L, maxUInt.getValue());
+    }
+
+    @Test
+    public void testBig() {
+        long testValue = (long) Integer.MAX_VALUE + 5L;
+        LittleEndianUInt32 big = new LittleEndianUInt32(testValue);
+        assertEquals(big.getValue(), testValue);
+    }
+
+    public byte[] asByte(int[] bytes) {
+        byte[] result = new byte[bytes.length];
+        for(int i=0; i<bytes.length; i++) {
+            result[i] = (byte) bytes[i];
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
- Introduced a new class `LittleEndianUInt32` for storing little-endian unsigned 32-bit integers.  This class allows the unsigned value to be retrieved as a long on-demand, thus allowing the full range of unsigned values without taking up any additional space, thus addressing issue #70.
- Reformatted code to adhere to style guidelines.
- Fixed javadoc comment format and dangling javadoc.
- Added methods `getEpochTime` and `getDate` to `BitcoinBlock`.