### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: java
 script:
 - jdk_switcher use openjdk8
 - ./gradlew clean
-- travis_wait ./gradlew build
+- ./gradlew build
 - ./gradlew test
 - ./gradlew integrationTest
 - sonar-scanner -Dsonar.login=$SONAR_HCL
@@ -18,3 +18,8 @@ after_success:
 - .travis/publish-junitreport.sh
 - .travis/publish-pitest.sh
 - .travis/publish-owaspdependency.sh
+
+cache:
+  directories:
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
